### PR TITLE
refactor: switch to hex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1698,6 +1698,7 @@ dependencies = [
  "anyhow",
  "async-channel",
  "bytes",
+ "data-encoding",
  "derive_more",
  "ed25519-dalek",
  "futures-buffered",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ tokio = { version = "1", features = ["sync", "macros"] }
 proptest = "1.2.0"
 tempfile = "3.4"
 test-strategy = "0.3.1"
+data-encoding = "2.6.0"
 
 [features]
 default = ["net", "metrics", "engine"]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -296,7 +296,7 @@ impl LiveEvent {
 /// engine. Changing the default author will not be persisted.
 ///
 /// If set to `Persistent`, the default author will be loaded from and persisted to the specified
-/// path (as base32 encoded string of the author's public key).
+/// path (as hex encoded string of the author's public key).
 #[derive(Debug)]
 pub enum DefaultAuthorStorage {
     /// Memory storage.

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -3,7 +3,6 @@
 use std::{cmp::Ordering, fmt, str::FromStr};
 
 use ed25519_dalek::{Signature, SignatureError, Signer, SigningKey, VerifyingKey};
-use iroh_base::base32;
 use rand_core::CryptoRngCore;
 use serde::{Deserialize, Serialize};
 
@@ -160,37 +159,37 @@ impl NamespacePublicKey {
 
 impl fmt::Display for Author {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", base32::fmt(self.to_bytes()))
+        write!(f, "{}", hex::encode(self.to_bytes()))
     }
 }
 
 impl fmt::Display for NamespaceSecret {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", base32::fmt(self.to_bytes()))
+        write!(f, "{}", hex::encode(self.to_bytes()))
     }
 }
 
 impl fmt::Display for AuthorPublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", base32::fmt(self.as_bytes()))
+        write!(f, "{}", hex::encode(self.as_bytes()))
     }
 }
 
 impl fmt::Display for NamespacePublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", base32::fmt(self.as_bytes()))
+        write!(f, "{}", hex::encode(self.as_bytes()))
     }
 }
 
 impl fmt::Display for AuthorId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", base32::fmt(self.as_bytes()))
+        write!(f, "{}", hex::encode(self.as_bytes()))
     }
 }
 
 impl fmt::Display for NamespaceId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", base32::fmt(self.as_bytes()))
+        write!(f, "{}", hex::encode(self.as_bytes()))
     }
 }
 
@@ -202,13 +201,13 @@ impl fmt::Debug for NamespaceSecret {
 
 impl fmt::Debug for NamespaceId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "NamespaceId({})", base32::fmt_short(self.0))
+        write!(f, "NamespaceId({})", hex::encode(self.0))
     }
 }
 
 impl fmt::Debug for AuthorId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "AuthorId({})", base32::fmt_short(self.0))
+        write!(f, "AuthorId({})", hex::encode(self.0))
     }
 }
 
@@ -230,11 +229,17 @@ impl fmt::Debug for AuthorPublicKey {
     }
 }
 
+fn parse_hex_array(s: &str) -> anyhow::Result<[u8; 32]> {
+    let mut bytes = [0u8; 32];
+    hex::decode_to_slice(s, &mut bytes)?;
+    Ok(bytes)
+}
+
 impl FromStr for Author {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self::from_bytes(&base32::parse_array(s)?))
+        Ok(Self::from_bytes(&parse_hex_array(s)?))
     }
 }
 
@@ -242,7 +247,7 @@ impl FromStr for NamespaceSecret {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self::from_bytes(&base32::parse_array(s)?))
+        Ok(Self::from_bytes(&parse_hex_array(s)?))
     }
 }
 
@@ -250,7 +255,7 @@ impl FromStr for AuthorPublicKey {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Self::from_bytes(&base32::parse_array(s)?).map_err(Into::into)
+        Self::from_bytes(&parse_hex_array(s)?).map_err(Into::into)
     }
 }
 
@@ -258,7 +263,7 @@ impl FromStr for NamespacePublicKey {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Self::from_bytes(&base32::parse_array(s)?).map_err(Into::into)
+        Self::from_bytes(&parse_hex_array(s)?).map_err(Into::into)
     }
 }
 
@@ -386,10 +391,10 @@ impl AuthorId {
         AuthorPublicKey::from_bytes(&self.0)
     }
 
-    /// Convert to a base32 string limited to the first 10 bytes for a friendly string
+    /// Convert to a hex string limited to the first 10 bytes for a friendly string
     /// representation of the key.
     pub fn fmt_short(&self) -> String {
-        base32::fmt_short(self.0)
+        hex::encode(self.0).chars().take(10).collect()
     }
 }
 
@@ -421,10 +426,10 @@ impl NamespaceId {
         NamespacePublicKey::from_bytes(&self.0)
     }
 
-    /// Convert to a base32 string limited to the first 10 bytes for a friendly string
+    /// Convert to a hex string limited to the first 10 bytes for a friendly string
     /// representation of the key.
     pub fn fmt_short(&self) -> String {
-        base32::fmt_short(self.0)
+        hex::encode(self.0).chars().take(10).collect()
     }
 }
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -16,7 +16,7 @@ use std::{
 
 use bytes::{Bytes, BytesMut};
 use ed25519_dalek::{Signature, SignatureError};
-use iroh_base::{base32, hash::Hash};
+use iroh_base::hash::Hash;
 #[cfg(feature = "metrics")]
 use iroh_metrics::{inc, inc_by};
 use serde::{Deserialize, Serialize};
@@ -826,11 +826,11 @@ impl Debug for EntrySignature {
         f.debug_struct("EntrySignature")
             .field(
                 "namespace_signature",
-                &base32::fmt(self.namespace_signature.to_bytes()),
+                &hex::encode(self.namespace_signature.to_bytes()),
             )
             .field(
                 "author_signature",
-                &base32::fmt(self.author_signature.to_bytes()),
+                &hex::encode(self.author_signature.to_bytes()),
             )
             .finish()
     }

--- a/src/ticket.rs
+++ b/src/ticket.rs
@@ -89,7 +89,14 @@ mod tests {
             nodes: vec![NodeAddr::from_parts(node_id, None, [])],
         };
         let s = ticket.to_string();
-        let base32 = data_encoding::BASE32_NOPAD.decode(s.strip_prefix("doc").unwrap().to_ascii_uppercase().as_bytes()).unwrap();
+        let base32 = data_encoding::BASE32_NOPAD
+            .decode(
+                s.strip_prefix("doc")
+                    .unwrap()
+                    .to_ascii_uppercase()
+                    .as_bytes(),
+            )
+            .unwrap();
         let expected = parse_hexdump("
             00 # variant
             01 # capability discriminator, 1 = read

--- a/src/ticket.rs
+++ b/src/ticket.rs
@@ -65,7 +65,6 @@ impl std::str::FromStr for DocTicket {
 mod tests {
     use std::str::FromStr;
 
-    use iroh_base::base32;
     use iroh_net::key::PublicKey;
     use iroh_test::{assert_eq_hex, hexdump::parse_hexdump};
 
@@ -89,7 +88,8 @@ mod tests {
             capability: Capability::Read(namespace_id),
             nodes: vec![NodeAddr::from_parts(node_id, None, [])],
         };
-        let base32 = base32::parse_vec(ticket.to_string().strip_prefix("doc").unwrap()).unwrap();
+        let s = ticket.to_string();
+        let base32 = data_encoding::BASE32_NOPAD.decode(s.strip_prefix("doc").unwrap().to_ascii_uppercase().as_bytes()).unwrap();
         let expected = parse_hexdump("
             00 # variant
             01 # capability discriminator, 1 = read


### PR DESCRIPTION
## Breaking Changes

- `Author`, `Namespace` and `NamespaceSecret`s are now encoded and parsed as hex instead of base32


Ref https://github.com/n0-computer/iroh/issues/2841
