### PR TITLE
feat: add mem rpc client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3394,8 +3394,7 @@ dependencies = [
 [[package]]
 name = "quic-rpc"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e131f594054d27d077162815db3b5e9ddd76a28fbb9091b68095971e75c286"
+source = "git+https://github.com/n0-computer/quic-rpc?branch=main#32d5bc1a08609f4f0b5650980088f07d81971a55"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -3409,6 +3408,7 @@ dependencies = [
  "serde",
  "slab",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3393,8 +3393,9 @@ dependencies = [
 
 [[package]]
 name = "quic-rpc"
-version = "0.15.0"
-source = "git+https://github.com/n0-computer/quic-rpc?branch=main#32d5bc1a08609f4f0b5650980088f07d81971a55"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc623a188942fc875926f7baeb2cb08ed4288b64f29072656eb051e360ee7623"
 dependencies = [
  "anyhow",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,3 +105,4 @@ iroh-metrics = { git = "https://github.com/n0-computer/iroh", branch = "main" }
 iroh-base = { git = "https://github.com/n0-computer/iroh", branch = "main" }
 iroh-blobs = { git = "https://github.com/n0-computer/iroh-blobs", branch = "main" }
 iroh-gossip = { git = "https://github.com/n0-computer/iroh-gossip", branch = "main" }
+quic-rpc = { git = "https://github.com/n0-computer/quic-rpc", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ tracing = "0.1"
 
 # rpc
 nested_enum_utils = { version = "0.1.0", optional = true }
-quic-rpc = { version = "0.15", optional = true }
+quic-rpc = { version = "0.15.1", optional = true }
 quic-rpc-derive = { version = "0.15", optional = true }
 serde-error = { version = "0.1.3", optional = true }
 portable-atomic = { version = "1.9.0", optional = true }
@@ -105,4 +105,3 @@ iroh-metrics = { git = "https://github.com/n0-computer/iroh", branch = "main" }
 iroh-base = { git = "https://github.com/n0-computer/iroh", branch = "main" }
 iroh-blobs = { git = "https://github.com/n0-computer/iroh-blobs", branch = "main" }
 iroh-gossip = { git = "https://github.com/n0-computer/iroh-gossip", branch = "main" }
-quic-rpc = { git = "https://github.com/n0-computer/quic-rpc", branch = "main" }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -6,7 +6,7 @@ use std::{
     io,
     path::PathBuf,
     str::FromStr,
-    sync::{Arc, OnceLock, RwLock},
+    sync::{Arc, RwLock},
 };
 
 use anyhow::{bail, Context, Result};
@@ -57,7 +57,7 @@ pub struct Engine<D> {
     local_pool_handle: LocalPoolHandle,
     blob_store: D,
     #[cfg(feature = "rpc")]
-    pub(crate) rpc_handler: Arc<OnceLock<crate::rpc::RpcHandler>>,
+    pub(crate) rpc_handler: Arc<std::sync::OnceLock<crate::rpc::RpcHandler>>,
 }
 
 impl<D: iroh_blobs::store::Store> Engine<D> {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -6,7 +6,7 @@ use std::{
     io,
     path::PathBuf,
     str::FromStr,
-    sync::{Arc, RwLock},
+    sync::{Arc, OnceLock, RwLock},
 };
 
 use anyhow::{bail, Context, Result};
@@ -56,6 +56,8 @@ pub struct Engine<D> {
     content_status_cb: ContentStatusCallback,
     local_pool_handle: LocalPoolHandle,
     blob_store: D,
+    #[cfg(feature = "rpc")]
+    pub(crate) rpc_handler: Arc<OnceLock<crate::rpc::RpcHandler>>,
 }
 
 impl<D: iroh_blobs::store::Store> Engine<D> {
@@ -118,6 +120,8 @@ impl<D: iroh_blobs::store::Store> Engine<D> {
             default_author: Arc::new(default_author),
             local_pool_handle,
             blob_store: bao_store,
+            #[cfg(feature = "rpc")]
+            rpc_handler: Default::default(),
         })
     }
 

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1,9 +1,8 @@
 //! Quic RPC implementation for docs.
 
-use proto::{Request, Response, RpcService};
+use proto::{Request, RpcService};
 use quic_rpc::{
     server::{ChannelTypes, RpcChannel},
-    transport::flume::FlumeConnector,
     RpcClient, RpcServer,
 };
 use tokio_util::task::AbortOnDropHandle;
@@ -20,7 +19,7 @@ type RpcResult<T> = std::result::Result<T, RpcError>;
 
 impl<D: iroh_blobs::store::Store> Engine<D> {
     /// Get an in memory client to interact with the docs engine.
-    pub fn client(&self) -> &client::docs::Client<FlumeConnector<Response, Request>> {
+    pub fn client(&self) -> &client::docs::MemClient {
         &self
             .rpc_handler
             .get_or_init(|| RpcHandler::new(self))
@@ -81,7 +80,7 @@ impl<D: iroh_blobs::store::Store> Engine<D> {
 #[derive(Debug)]
 pub(crate) struct RpcHandler {
     /// Client to hand out
-    client: client::docs::Client<FlumeConnector<Response, Request>>,
+    client: client::docs::MemClient,
     /// Handler task
     _handler: AbortOnDropHandle<()>,
 }
@@ -91,7 +90,7 @@ impl RpcHandler {
         let engine = engine.clone();
         let (listener, connector) = quic_rpc::transport::flume::channel(1);
         let listener = RpcServer::new(listener);
-        let client = client::docs::Client::new(RpcClient::new(connector));
+        let client = client::docs::MemClient::new(RpcClient::new(connector));
         let _handler = listener
             .spawn_accept_loop(move |req, chan| engine.clone().handle_rpc_request(req, chan));
         Self { client, _handler }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1,6 +1,6 @@
 //! Quic RPC implementation for docs.
 
-use proto::RpcService;
+use proto::{Request, Response, RpcService};
 use quic_rpc::{
     server::{ChannelTypes, RpcChannel},
     transport::flume::FlumeConnector,
@@ -20,11 +20,7 @@ type RpcResult<T> = std::result::Result<T, RpcError>;
 
 impl<D: iroh_blobs::store::Store> Engine<D> {
     /// Get an in memory client to interact with the docs engine.
-    pub fn client(
-        &self,
-    ) -> &crate::rpc::client::docs::Client<
-        FlumeConnector<crate::rpc::proto::Response, crate::rpc::proto::Request>,
-    > {
+    pub fn client(&self) -> &client::docs::Client<FlumeConnector<Response, Request>> {
         &self
             .rpc_handler
             .get_or_init(|| RpcHandler::new(self))
@@ -34,10 +30,10 @@ impl<D: iroh_blobs::store::Store> Engine<D> {
     /// Handle a docs request from the RPC server.
     pub async fn handle_rpc_request<C: ChannelTypes<RpcService>>(
         self,
-        msg: crate::rpc::proto::Request,
+        msg: Request,
         chan: RpcChannel<RpcService, C>,
     ) -> Result<(), quic_rpc::server::RpcServerError<C>> {
-        use crate::rpc::proto::Request::*;
+        use Request::*;
         let this = self;
         match msg {
             Open(msg) => chan.rpc(msg, this, Self::doc_open).await,
@@ -85,9 +81,7 @@ impl<D: iroh_blobs::store::Store> Engine<D> {
 #[derive(Debug)]
 pub(crate) struct RpcHandler {
     /// Client to hand out
-    client: crate::rpc::client::docs::Client<
-        FlumeConnector<crate::rpc::proto::Response, crate::rpc::proto::Request>,
-    >,
+    client: client::docs::Client<FlumeConnector<Response, Request>>,
     /// Handler task
     _handler: AbortOnDropHandle<()>,
 }
@@ -97,7 +91,7 @@ impl RpcHandler {
         let engine = engine.clone();
         let (listener, connector) = quic_rpc::transport::flume::channel(1);
         let listener = RpcServer::new(listener);
-        let client = crate::rpc::client::docs::Client::new(RpcClient::new(connector));
+        let client = client::docs::Client::new(RpcClient::new(connector));
         let _handler = listener
             .spawn_accept_loop(move |req, chan| engine.clone().handle_rpc_request(req, chan));
         Self { client, _handler }

--- a/src/rpc/client/authors.rs
+++ b/src/rpc/client/authors.rs
@@ -19,6 +19,7 @@ use crate::{
 
 /// Iroh docs client.
 #[derive(Debug, Clone)]
+#[repr(transparent)]
 pub struct Client<C = BoxedConnector<RpcService>> {
     pub(super) rpc: quic_rpc::RpcClient<RpcService, C>,
 }

--- a/src/rpc/client/docs.rs
+++ b/src/rpc/client/docs.rs
@@ -16,7 +16,9 @@ use iroh_base::node_addr::AddrInfoOptions;
 use iroh_blobs::{export::ExportProgress, store::ExportMode, Hash};
 use iroh_net::NodeAddr;
 use portable_atomic::{AtomicBool, Ordering};
-use quic_rpc::{client::BoxedConnector, message::RpcMsg, Connector};
+use quic_rpc::{
+    client::BoxedConnector, message::RpcMsg, transport::flume::FlumeConnector, Connector,
+};
 use serde::{Deserialize, Serialize};
 
 use super::{authors, flatten};
@@ -37,6 +39,10 @@ pub use crate::{
     engine::{LiveEvent, Origin, SyncEvent, SyncReason},
     Entry,
 };
+
+/// Type alias for a memory-backed client.
+pub type MemClient =
+    Client<FlumeConnector<crate::rpc::proto::Response, crate::rpc::proto::Request>>;
 
 /// Iroh docs client.
 #[derive(Debug, Clone)]

--- a/src/rpc/client/docs.rs
+++ b/src/rpc/client/docs.rs
@@ -40,6 +40,7 @@ pub use crate::{
 
 /// Iroh docs client.
 #[derive(Debug, Clone)]
+#[repr(transparent)]
 pub struct Client<C = BoxedConnector<RpcService>> {
     pub(super) rpc: quic_rpc::RpcClient<RpcService, C>,
 }

--- a/src/rpc/client/docs.rs
+++ b/src/rpc/client/docs.rs
@@ -19,7 +19,7 @@ use portable_atomic::{AtomicBool, Ordering};
 use quic_rpc::{client::BoxedConnector, message::RpcMsg, Connector};
 use serde::{Deserialize, Serialize};
 
-use super::flatten;
+use super::{authors, flatten};
 use crate::{
     actor::OpenState,
     rpc::proto::{
@@ -48,6 +48,11 @@ impl<C: Connector<RpcService>> Client<C> {
     /// Creates a new docs client.
     pub fn new(rpc: quic_rpc::RpcClient<RpcService, C>) -> Self {
         Self { rpc }
+    }
+
+    /// Returns an authors client.
+    pub fn authors(&self) -> authors::Client<C> {
+        authors::Client::new(self.rpc.clone())
     }
 
     /// Creates a client.


### PR DESCRIPTION
## Description

Add the ability to get a memory RPC client for docs, just like https://github.com/n0-computer/iroh-gossip/pull/7

## Breaking Changes



## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
