### PR TITLE
experiment: align rpc and regular api

### DIFF
--- a/src/actor.rs
+++ b/src/actor.rs
@@ -32,11 +32,18 @@ use crate::{
 const ACTION_CAP: usize = 1024;
 pub(crate) const MAX_COMMIT_DELAY: Duration = Duration::from_millis(500);
 
+/// Import an author action.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ImportAuthorAction {
+    /// The author to import.
+    pub author: Author,
+}
+
 #[derive(derive_more::Debug, derive_more::Display)]
 enum Action {
     #[display("NewAuthor")]
     ImportAuthor {
-        author: Author,
+        action: ImportAuthorAction,
         #[debug("reply")]
         reply: oneshot::Sender<Result<AuthorId>>,
     },
@@ -500,9 +507,20 @@ impl SyncHandle {
         self.send(Action::ListReplicas { reply }).await
     }
 
+    /// Imports the given author.
+    ///
+    /// Warning: The [`Author`] struct contains sensitive data.
     pub async fn import_author(&self, author: Author) -> Result<AuthorId> {
+        self.import_author_action(ImportAuthorAction { author })
+            .await
+    }
+
+    pub(crate) async fn import_author_action(
+        &self,
+        action: ImportAuthorAction,
+    ) -> Result<AuthorId> {
         let (reply, rx) = oneshot::channel();
-        self.send(Action::ImportAuthor { author, reply }).await?;
+        self.send(Action::ImportAuthor { action, reply }).await?;
         rx.await?
     }
 
@@ -663,9 +681,9 @@ impl Actor {
             Action::Shutdown { .. } => {
                 unreachable!("Shutdown is handled in run()")
             }
-            Action::ImportAuthor { author, reply } => {
-                let id = author.id();
-                send_reply(reply, self.store.import_author(author).map(|_| id))
+            Action::ImportAuthor { action, reply } => {
+                let id = action.author.id();
+                send_reply(reply, self.store.import_author(action.author).map(|_| id))
             }
             Action::ExportAuthor { author, reply } => {
                 send_reply(reply, self.store.get_author(&author))

--- a/src/rpc/client/authors.rs
+++ b/src/rpc/client/authors.rs
@@ -10,9 +10,10 @@ use super::flatten;
 #[doc(inline)]
 pub use crate::engine::{Origin, SyncEvent, SyncReason};
 use crate::{
+    actor::ImportAuthorAction,
     rpc::proto::{
         AuthorCreateRequest, AuthorDeleteRequest, AuthorExportRequest, AuthorGetDefaultRequest,
-        AuthorImportRequest, AuthorListRequest, AuthorSetDefaultRequest, RpcService,
+        AuthorListRequest, AuthorSetDefaultRequest, RpcService,
     },
     Author, AuthorId,
 };
@@ -85,7 +86,7 @@ impl<C: Connector<RpcService>> Client<C> {
     ///
     /// Warning: The [`Author`] struct contains sensitive data.
     pub async fn import(&self, author: Author) -> Result<()> {
-        self.rpc.rpc(AuthorImportRequest { author }).await??;
+        self.rpc.rpc(ImportAuthorAction { author }).await??;
         Ok(())
     }
 

--- a/src/rpc/docs_handle_request.rs
+++ b/src/rpc/docs_handle_request.rs
@@ -14,11 +14,11 @@ use super::{
     proto::{
         AuthorCreateRequest, AuthorCreateResponse, AuthorDeleteRequest, AuthorDeleteResponse,
         AuthorExportRequest, AuthorExportResponse, AuthorGetDefaultRequest,
-        AuthorGetDefaultResponse, AuthorImportRequest, AuthorImportResponse, AuthorListRequest,
-        AuthorListResponse, AuthorSetDefaultRequest, AuthorSetDefaultResponse, CloseRequest,
-        CloseResponse, CreateRequest as DocCreateRequest, CreateResponse as DocCreateResponse,
-        DelRequest, DelResponse, DocListRequest, DocSubscribeRequest, DocSubscribeResponse,
-        DropRequest, DropResponse, ExportFileRequest, ExportFileResponse, GetDownloadPolicyRequest,
+        AuthorGetDefaultResponse, AuthorImportResponse, AuthorListRequest, AuthorListResponse,
+        AuthorSetDefaultRequest, AuthorSetDefaultResponse, CloseRequest, CloseResponse,
+        CreateRequest as DocCreateRequest, CreateResponse as DocCreateResponse, DelRequest,
+        DelResponse, DocListRequest, DocSubscribeRequest, DocSubscribeResponse, DropRequest,
+        DropResponse, ExportFileRequest, ExportFileResponse, GetDownloadPolicyRequest,
         GetDownloadPolicyResponse, GetExactRequest, GetExactResponse, GetManyRequest,
         GetManyResponse, GetSyncPeersRequest, GetSyncPeersResponse, ImportFileRequest,
         ImportFileResponse, ImportRequest as DocImportRequest, ImportResponse as DocImportResponse,
@@ -29,7 +29,7 @@ use super::{
     },
     RpcError, RpcResult,
 };
-use crate::{engine::Engine, Author, DocTicket, NamespaceSecret};
+use crate::{actor::ImportAuthorAction, engine::Engine, Author, DocTicket, NamespaceSecret};
 
 /// Capacity for the flume channels to forward sync store iterators to async RPC streams.
 const ITER_CHANNEL_CAP: usize = 64;
@@ -91,13 +91,14 @@ impl<D: iroh_blobs::store::Store> Engine<D> {
 
     pub(super) async fn author_import(
         self,
-        req: AuthorImportRequest,
+        req: ImportAuthorAction,
     ) -> RpcResult<AuthorImportResponse> {
         let author_id = self
             .sync
-            .import_author(req.author)
+            .import_author_action(req)
             .await
             .map_err(|e| RpcError::new(&*e))?;
+
         Ok(AuthorImportResponse { author_id })
     }
 

--- a/src/rpc/proto.rs
+++ b/src/rpc/proto.rs
@@ -15,7 +15,7 @@ use super::{
     RpcError, RpcResult,
 };
 use crate::{
-    actor::OpenState,
+    actor::{ImportAuthorAction, OpenState},
     engine::LiveEvent,
     store::{DownloadPolicy, Query},
     Author, AuthorId, Capability, CapabilityKind, DocTicket, Entry, NamespaceId, PeerIdBytes,
@@ -87,7 +87,7 @@ pub enum Request {
     #[rpc(response = RpcResult<AuthorSetDefaultResponse>)]
     AuthorSetDefault(AuthorSetDefaultRequest),
     #[rpc(response = RpcResult<AuthorImportResponse>)]
-    AuthorImport(AuthorImportRequest),
+    AuthorImport(ImportAuthorAction),
     #[rpc(response = RpcResult<AuthorExportResponse>)]
     AuthorExport(AuthorExportRequest),
     #[rpc(response = RpcResult<AuthorDeleteResponse>)]
@@ -522,13 +522,6 @@ pub struct AuthorExportRequest {
 pub struct AuthorExportResponse {
     /// The author
     pub author: Option<Author>,
-}
-
-/// Import author from secret key
-#[derive(Serialize, Deserialize, Debug)]
-pub struct AuthorImportRequest {
-    /// The author to import
-    pub author: Author,
 }
 
 /// Response to [`ImportRequest`]


### PR DESCRIPTION
This makes `client().authors().import()` and `engine.sync.import_author()` use the same types and structures under the hood, so they become interchangable