### PR TITLE
feat!: Add Docs<S> which wraps the Engine<S>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2207,7 +2207,7 @@ dependencies = [
 [[package]]
 name = "iroh-gossip"
 version = "0.29.0"
-source = "git+https://github.com/n0-computer/iroh-gossip?branch=main#d5285e7240da4e233be7c8f83099741f6f272bb0"
+source = "git+https://github.com/n0-computer/iroh-gossip?branch=main#0e6fd20203c6468af9d783f1e62379eca283188a"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ futures-util = { version = "0.3.25" }
 hex = "0.4"
 iroh-base = { version = "0.29" }
 iroh-blobs = { version = "0.29.0", optional = true, features = ["downloader"] }
-iroh-gossip = { version = "0.29.0", optional = true }
+iroh-gossip = { version = "0.29.0", optional = true, features = ["net"] }
 iroh-metrics = { version = "0.29.0", default-features = false }
 iroh = { version = "0.29", optional = true }
 num_enum = "0.7"

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,23 +1,129 @@
 //! [`ProtocolHandler`] implementation for the docs [`Engine`].
 
+use std::{path::PathBuf, sync::Arc};
+
 use anyhow::Result;
 use futures_lite::future::Boxed as BoxedFuture;
 use iroh::{endpoint::Connecting, protocol::ProtocolHandler};
+use iroh_blobs::net_protocol::{Blobs, ProtectCb};
+use iroh_gossip::net::Gossip;
+use quic_rpc::server::{ChannelTypes, RpcChannel};
 
-use crate::engine::Engine;
+use crate::{
+    engine::{DefaultAuthorStorage, Engine},
+    rpc::proto::{Request, RpcService},
+    store::Store,
+};
 
-impl<D: iroh_blobs::store::Store> ProtocolHandler for Engine<D> {
+impl<S: iroh_blobs::store::Store> ProtocolHandler for Docs<S> {
     fn accept(&self, conn: Connecting) -> BoxedFuture<Result<()>> {
-        let this = self.clone();
+        let this = self.engine.clone();
         Box::pin(async move { this.handle_connection(conn).await })
     }
 
     fn shutdown(&self) -> BoxedFuture<()> {
-        let this = self.clone();
+        let this = self.engine.clone();
         Box::pin(async move {
             if let Err(err) = this.shutdown().await {
                 tracing::warn!("shutdown error: {:?}", err);
             }
+        })
+    }
+}
+
+/// Docs protocol.
+#[derive(Debug, Clone)]
+pub struct Docs<S> {
+    engine: Arc<Engine<S>>,
+    #[cfg(feature = "rpc")]
+    pub(crate) rpc_handler: Arc<std::sync::OnceLock<crate::rpc::RpcHandler>>,
+}
+
+impl Docs<()> {
+    /// Create a new [`Builder`] for the docs protocol, using in memory replica and author storage.
+    pub fn memory() -> Builder {
+        Builder::default()
+    }
+
+    /// Create a new [`Builder`] for the docs protocol, using a persistent replica and author storage
+    /// in the given directory.
+    pub fn persistent(path: PathBuf) -> Builder {
+        Builder { path: Some(path) }
+    }
+}
+
+impl<S: iroh_blobs::store::Store> Docs<S> {
+    /// Get an in memory client to interact with the docs engine.
+    pub fn client(&self) -> &crate::rpc::client::docs::MemClient {
+        &self
+            .rpc_handler
+            .get_or_init(|| crate::rpc::RpcHandler::new(&self.engine))
+            .client
+    }
+
+    /// Create a new docs protocol with the given engine.
+    ///
+    /// Note that usually you would use the [`Builder`] to create a new docs protocol.
+    pub fn new(engine: Engine<S>) -> Self {
+        Self {
+            engine: Arc::new(engine),
+            rpc_handler: Default::default(),
+        }
+    }
+
+    /// Handle a docs request from the RPC server.
+    pub async fn handle_rpc_request<C: ChannelTypes<RpcService>>(
+        self,
+        msg: Request,
+        chan: RpcChannel<RpcService, C>,
+    ) -> Result<(), quic_rpc::server::RpcServerError<C>> {
+        self.engine
+            .as_ref()
+            .clone()
+            .handle_rpc_request(msg, chan)
+            .await
+    }
+
+    /// Get the protect callback for the docs engine.
+    pub fn protect_cb(&self) -> ProtectCb {
+        self.engine.protect_cb()
+    }
+}
+
+/// Builder for the docs protocol.
+#[derive(Debug, Default)]
+pub struct Builder {
+    path: Option<PathBuf>,
+}
+
+impl Builder {
+    /// Build a [`Docs`] protocol given a [`Blobs`] and [`Gossip`] protocol.
+    pub async fn build<S: iroh_blobs::store::Store>(
+        self,
+        blobs: &Blobs<S>,
+        gossip: &Gossip,
+    ) -> anyhow::Result<Docs<S>> {
+        let replica_store = match self.path {
+            Some(ref path) => Store::persistent(path.join("docs.redb"))?,
+            None => Store::memory(),
+        };
+        let author_store = match self.path {
+            Some(ref path) => DefaultAuthorStorage::Persistent(path.join("default-author")),
+            None => DefaultAuthorStorage::Mem,
+        };
+        let engine = Engine::spawn(
+            blobs.endpoint().clone(),
+            gossip.clone(),
+            replica_store,
+            blobs.store().clone(),
+            blobs.downloader().clone(),
+            author_store,
+            blobs.rt().clone(),
+        )
+        .await?;
+        Ok(Docs {
+            engine: Arc::new(engine),
+            rpc_handler: Default::default(),
         })
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -7,11 +7,9 @@ use futures_lite::future::Boxed as BoxedFuture;
 use iroh::{endpoint::Connecting, protocol::ProtocolHandler};
 use iroh_blobs::net_protocol::{Blobs, ProtectCb};
 use iroh_gossip::net::Gossip;
-use quic_rpc::server::{ChannelTypes, RpcChannel};
 
 use crate::{
     engine::{DefaultAuthorStorage, Engine},
-    rpc::proto::{Request, RpcService},
     store::Store,
 };
 
@@ -74,10 +72,12 @@ impl<S: iroh_blobs::store::Store> Docs<S> {
 
     /// Handle a docs request from the RPC server.
     #[cfg(feature = "rpc")]
-    pub async fn handle_rpc_request<C: ChannelTypes<RpcService>>(
+    pub async fn handle_rpc_request<
+        C: quic_rpc::server::ChannelTypes<crate::rpc::proto::RpcService>,
+    >(
         self,
-        msg: Request,
-        chan: RpcChannel<RpcService, C>,
+        msg: crate::rpc::proto::Request,
+        chan: quic_rpc::server::RpcChannel<crate::rpc::proto::RpcService, C>,
     ) -> Result<(), quic_rpc::server::RpcServerError<C>> {
         crate::rpc::Handler(self.engine.clone())
             .handle_rpc_request(msg, chan)

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "rpc")]
 //! [`ProtocolHandler`] implementation for the docs [`Engine`].
 
 use std::{path::PathBuf, sync::Arc};

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -66,6 +66,7 @@ impl<S: iroh_blobs::store::Store> Docs<S> {
     pub fn new(engine: Engine<S>) -> Self {
         Self {
             engine: Arc::new(engine),
+            #[cfg(feature = "rpc")]
             rpc_handler: Default::default(),
         }
     }
@@ -121,9 +122,6 @@ impl Builder {
             blobs.rt().clone(),
         )
         .await?;
-        Ok(Docs {
-            engine: Arc::new(engine),
-            rpc_handler: Default::default(),
-        })
+        Ok(Docs::new(engine))
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,4 +1,3 @@
-#![cfg(feature = "rpc")]
 //! [`ProtocolHandler`] implementation for the docs [`Engine`].
 
 use std::{path::PathBuf, sync::Arc};
@@ -55,6 +54,7 @@ impl Docs<()> {
 
 impl<S: iroh_blobs::store::Store> Docs<S> {
     /// Get an in memory client to interact with the docs engine.
+    #[cfg(feature = "rpc")]
     pub fn client(&self) -> &crate::rpc::client::docs::MemClient {
         &self
             .rpc_handler
@@ -73,6 +73,7 @@ impl<S: iroh_blobs::store::Store> Docs<S> {
     }
 
     /// Handle a docs request from the RPC server.
+    #[cfg(feature = "rpc")]
     pub async fn handle_rpc_request<C: ChannelTypes<RpcService>>(
         self,
         msg: Request,
@@ -99,7 +100,7 @@ pub struct Builder {
 
 impl Builder {
     /// Build a [`Docs`] protocol given a [`Blobs`] and [`Gossip`] protocol.
-    pub async fn build<S: iroh_blobs::store::Store>(
+    pub async fn spawn<S: iroh_blobs::store::Store>(
         self,
         blobs: &Blobs<S>,
         gossip: &Gossip,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -58,7 +58,7 @@ impl<S: iroh_blobs::store::Store> Docs<S> {
     pub fn client(&self) -> &crate::rpc::client::docs::MemClient {
         &self
             .rpc_handler
-            .get_or_init(|| crate::rpc::RpcHandler::new(&self.engine))
+            .get_or_init(|| crate::rpc::RpcHandler::new(self.engine.clone()))
             .client
     }
 
@@ -79,9 +79,7 @@ impl<S: iroh_blobs::store::Store> Docs<S> {
         msg: Request,
         chan: RpcChannel<RpcService, C>,
     ) -> Result<(), quic_rpc::server::RpcServerError<C>> {
-        self.engine
-            .as_ref()
-            .clone()
+        crate::rpc::Handler(self.engine.clone())
             .handle_rpc_request(msg, chan)
             .await
     }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -80,13 +80,13 @@ impl<D: iroh_blobs::store::Store> Engine<D> {
 #[derive(Debug)]
 pub(crate) struct RpcHandler {
     /// Client to hand out
-    client: client::docs::MemClient,
+    pub(crate) client: client::docs::MemClient,
     /// Handler task
     _handler: AbortOnDropHandle<()>,
 }
 
 impl RpcHandler {
-    fn new<D: iroh_blobs::store::Store>(engine: &Engine<D>) -> Self {
+    pub fn new<D: iroh_blobs::store::Store>(engine: &Engine<D>) -> Self {
         let engine = engine.clone();
         let (listener, connector) = quic_rpc::transport::flume::channel(1);
         let listener = RpcServer::new(listener);

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1,5 +1,7 @@
 //! Quic RPC implementation for docs.
 
+use std::{ops::Deref, sync::Arc};
+
 use proto::{Request, RpcService};
 use quic_rpc::{
     server::{ChannelTypes, RpcChannel},
@@ -17,15 +19,18 @@ mod docs_handle_request;
 type RpcError = serde_error::Error;
 type RpcResult<T> = std::result::Result<T, RpcError>;
 
-impl<D: iroh_blobs::store::Store> Engine<D> {
-    /// Get an in memory client to interact with the docs engine.
-    pub fn client(&self) -> &client::docs::MemClient {
-        &self
-            .rpc_handler
-            .get_or_init(|| RpcHandler::new(self))
-            .client
-    }
+#[derive(Debug, Clone)]
+pub(crate) struct Handler<S>(pub(crate) Arc<Engine<S>>);
 
+impl<S> Deref for Handler<S> {
+    type Target = Engine<S>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<D: iroh_blobs::store::Store> Handler<D> {
     /// Handle a docs request from the RPC server.
     pub async fn handle_rpc_request<C: ChannelTypes<RpcService>>(
         self,
@@ -86,8 +91,8 @@ pub(crate) struct RpcHandler {
 }
 
 impl RpcHandler {
-    pub fn new<D: iroh_blobs::store::Store>(engine: &Engine<D>) -> Self {
-        let engine = engine.clone();
+    pub fn new<D: iroh_blobs::store::Store>(engine: Arc<Engine<D>>) -> Self {
+        let engine = Handler(engine);
         let (listener, connector) = quic_rpc::transport::flume::channel(1);
         let listener = RpcServer::new(listener);
         let client = client::docs::MemClient::new(RpcClient::new(connector));

--- a/src/rpc/docs_handle_request.rs
+++ b/src/rpc/docs_handle_request.rs
@@ -27,14 +27,14 @@ use super::{
         SetRequest, SetResponse, ShareRequest, ShareResponse, StartSyncRequest, StartSyncResponse,
         StatusRequest, StatusResponse,
     },
-    RpcError, RpcResult,
+    Handler, RpcError, RpcResult,
 };
-use crate::{engine::Engine, Author, DocTicket, NamespaceSecret};
+use crate::{Author, DocTicket, NamespaceSecret};
 
 /// Capacity for the flume channels to forward sync store iterators to async RPC streams.
 const ITER_CHANNEL_CAP: usize = 64;
 
-impl<D: iroh_blobs::store::Store> Engine<D> {
+impl<D: iroh_blobs::store::Store> Handler<D> {
     pub(super) async fn author_create(
         self,
         _req: AuthorCreateRequest,

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -136,7 +136,6 @@ impl<S: BlobStore> Builder<S> {
             builder = builder.dns_resolver(dns_resolver);
         }
         let endpoint = builder.bind().await?;
-        let addr = endpoint.node_addr().await?;
         let local_pool = LocalPool::single();
         let mut router = iroh::protocol::Router::builder(endpoint.clone());
         let blobs = Blobs::builder(store.clone()).build(&local_pool, &endpoint);

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -14,6 +14,7 @@ use iroh_blobs::{
     util::local_pool::LocalPool,
 };
 use iroh_docs::protocol::Docs;
+use iroh_gossip::net::Gossip;
 use nested_enum_utils::enum_conversions;
 use quic_rpc::transport::{Connector, Listener};
 use serde::{Deserialize, Serialize};
@@ -139,11 +140,7 @@ impl<S: BlobStore> Builder<S> {
         let local_pool = LocalPool::single();
         let mut router = iroh::protocol::Router::builder(endpoint.clone());
         let blobs = Blobs::builder(store.clone()).build(&local_pool, &endpoint);
-        let gossip = iroh_gossip::net::Gossip::from_endpoint(
-            endpoint.clone(),
-            Default::default(),
-            &addr.info,
-        );
+        let gossip = Gossip::builder().spawn(endpoint.clone()).await?;
         let builder = match self.path {
             Some(ref path) => Docs::persistent(path.to_path_buf()),
             None => Docs::memory(),

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -144,7 +144,7 @@ impl<S: BlobStore> Builder<S> {
             Some(ref path) => Docs::persistent(path.to_path_buf()),
             None => Docs::memory(),
         };
-        let docs = match builder.build(&blobs, &gossip).await {
+        let docs = match builder.spawn(&blobs, &gossip).await {
             Ok(docs) => docs,
             Err(err) => {
                 store.shutdown().await;


### PR DESCRIPTION

## Description

Add `Docs<S>` which wraps the `Engine<S>`

The `ProtocolHandler` is now implemented only for `Docs<S>`.

`Docs<S>` has a builder that takes a `Blobs<S>` and `Gossip<S>`, but there is also a way to create a Docs directly from an Engine.

## Breaking Changes

- Engine<S> no longer implements the ProtocolHandler trait