### PR TITLE
ci: Pin nextest version

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -66,7 +66,7 @@ jobs:
     - name: Install cargo-nextest
       uses: taiki-e/install-action@v2
       with:
-        tool: nextest
+        tool: nextest@0.9.80
 
     - name: Install sccache
       uses: mozilla-actions/sccache-action@v0.0.7


### PR DESCRIPTION
## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->
Nextest seems to have some issues with file descriptors in the latest version. This pins nextest to a 3 month old version so we get reliable flaky test runs again.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->
Related PR: https://github.com/n0-computer/iroh/pull/3088

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- ~~[ ] Tests if relevant.~~
- ~~[ ] All breaking changes documented.~~
