### PR TITLE
chore: patch to use main branch of iroh dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1998,8 +1998,7 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 [[package]]
 name = "iroh"
 version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ffd6af2e000f04972068c0318e0d8fa90ee9cfcb2bc6124db38591500e0278"
+source = "git+https://github.com/n0-computer/iroh.git?branch=main#0c7a1227cf1b9f640145c059c7581f2c502e6691"
 dependencies = [
  "aead",
  "anyhow",
@@ -2058,14 +2057,12 @@ dependencies = [
 [[package]]
 name = "iroh-base"
 version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "011d271a95b41218d22bdaf3352f29ef1dd7d6be644ca8543941655bec5f3d35"
+source = "git+https://github.com/n0-computer/iroh.git?branch=main#0c7a1227cf1b9f640145c059c7581f2c502e6691"
 dependencies = [
  "curve25519-dalek",
  "data-encoding",
  "derive_more",
  "ed25519-dalek",
- "getrandom 0.2.15",
  "postcard",
  "rand_core 0.6.4",
  "serde",
@@ -2089,8 +2086,7 @@ dependencies = [
 [[package]]
 name = "iroh-blobs"
 version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96cb8430c257cd42b2da9f94bc7e72912b182e760ab5c7fdbecd250d51de5e44"
+source = "git+https://github.com/n0-computer/iroh-blobs.git?branch=main#e35beb6b5007bdc9fae817fa711c9296c2e844a0"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -2198,8 +2194,7 @@ dependencies = [
 [[package]]
 name = "iroh-gossip"
 version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d4c7e330bf3d29576d443003e31a2d30d97b29ee13521af2634926d831c01d"
+source = "git+https://github.com/n0-computer/iroh-gossip.git?branch=main#0a03543db6aaedb7ac403e38360d5a1afc88b3f4"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -2261,8 +2256,7 @@ dependencies = [
 [[package]]
 name = "iroh-net-report"
 version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d2652f42eadc63458e36c0a422569f338639dc0b5bb469db0eb4a382b4e295c"
+source = "git+https://github.com/n0-computer/iroh.git?branch=main#0c7a1227cf1b9f640145c059c7581f2c502e6691"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2345,8 +2339,7 @@ dependencies = [
 [[package]]
 name = "iroh-relay"
 version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c930ccc4dfd0196b531344e3d0f83a0f82c45b170406e04a2491cba571faec5b"
+source = "git+https://github.com/n0-computer/iroh.git?branch=main#0c7a1227cf1b9f640145c059c7581f2c502e6691"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3533,8 +3526,7 @@ dependencies = [
 [[package]]
 name = "quic-rpc"
 version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ac46017d97c2ee3a7013c256a8ed00748b685ad8235f52245eb894706959c5"
+source = "git+https://github.com/n0-computer/quic-rpc.git?branch=main#ec27edbc1cba730d8bf54a61be06ffc62df3948e"
 dependencies = [
  "anyhow",
  "document-features",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,3 +117,10 @@ rpc = [
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "iroh_docsrs"]
+
+[patch.crates-io]
+iroh = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }
+quic-rpc = { git = "https://github.com/n0-computer/quic-rpc.git", branch = "main" }
+iroh-base = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }
+iroh-gossip = { git = "https://github.com/n0-computer/iroh-gossip.git", branch = "main" }
+iroh-blobs = { git = "https://github.com/n0-computer/iroh-blobs.git", branch = "main" }

--- a/deny.toml
+++ b/deny.toml
@@ -37,4 +37,4 @@ ignore = [
 ]
 
 [sources]
-allow-git = []
+allow-git = ["https://github.com/n0-computer/iroh.git", "https://github.com/n0-computer/quic-rpc.git", "https://github.com/n0-computer/iroh-blobs.git", "https://github.com/n0-computer/iroh-gossip.git"]


### PR DESCRIPTION
This PR updates the following dependencies to use their main branches:

- `iroh` from `https://github.com/n0-computer/iroh.git`
- `quic-rpc` from `https://github.com/n0-computer/quic-rpc.git`
- `iroh-base` from `https://github.com/n0-computer/iroh.git`
- `iroh-gossip` from `https://github.com/n0-computer/iroh-gossip.git`
- `iroh-blobs` from `https://github.com/n0-computer/iroh-blobs.git`