### PR TITLE
fix: Flaky tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,9 +688,9 @@ checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -4983,9 +4983,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1198,70 +1198,70 @@ impl ImportProgressBar {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    // use super::*;
 
-    #[tokio::test]
-    #[ignore]
-    #[allow(unused_variables, unreachable_code, clippy::diverging_sub_expression)]
-    async fn test_doc_import() -> Result<()> {
-        let temp_dir = tempfile::tempdir().context("tempdir")?;
+    // #[tokio::test]
+    // #[ignore]
+    // #[allow(unused_variables, unreachable_code, clippy::diverging_sub_expression)]
+    // async fn test_doc_import() -> Result<()> {
+    //     let temp_dir = tempfile::tempdir().context("tempdir")?;
 
-        tokio::fs::create_dir_all(temp_dir.path())
-            .await
-            .context("create dir all")?;
+    //     tokio::fs::create_dir_all(temp_dir.path())
+    //         .await
+    //         .context("create dir all")?;
 
-        let foobar = temp_dir.path().join("foobar");
-        tokio::fs::write(foobar, "foobar")
-            .await
-            .context("write foobar")?;
-        let foo = temp_dir.path().join("foo");
-        tokio::fs::write(foo, "foo").await.context("write foo")?;
+    //     let foobar = temp_dir.path().join("foobar");
+    //     tokio::fs::write(foobar, "foobar")
+    //         .await
+    //         .context("write foobar")?;
+    //     let foo = temp_dir.path().join("foo");
+    //     tokio::fs::write(foo, "foo").await.context("write foo")?;
 
-        let data_dir = tempfile::tempdir()?;
+    //     let data_dir = tempfile::tempdir()?;
 
-        //  let node = crate::commands::start::start_node(data_dir.path(), None, None).await?;
-        // let node = todo!();
-        // let client = node.client();
-        let docs: docs::Client = todo!();
-        let authors = docs.authors();
-        let doc = docs.create().await.context("doc create")?;
-        let author = authors.create().await.context("author create")?;
+    //     //  let node = crate::commands::start::start_node(data_dir.path(), None, None).await?;
+    //     // let node = todo!();
+    //     // let client = node.client();
+    //     let docs: docs::Client = todo!();
+    //     let authors = docs.authors();
+    //     let doc = docs.create().await.context("doc create")?;
+    //     let author = authors.create().await.context("author create")?;
 
-        // set up command, getting iroh node
-        let cli = ConsoleEnv::for_console(data_dir.path().to_owned(), &authors)
-            .await
-            .context("ConsoleEnv")?;
-        // let iroh = iroh::client::Iroh::connect_path(data_dir.path())
-        //     .await
-        //     .context("rpc connect")?;
-        // let iroh = todo!();
-        let docs = todo!();
-        let blobs = todo!();
+    //     // set up command, getting iroh node
+    //     let cli = ConsoleEnv::for_console(data_dir.path().to_owned(), &authors)
+    //         .await
+    //         .context("ConsoleEnv")?;
+    //     // let iroh = iroh::client::Iroh::connect_path(data_dir.path())
+    //     //     .await
+    //     //     .context("rpc connect")?;
+    //     // let iroh = todo!();
+    //     let docs = todo!();
+    //     let blobs = todo!();
 
-        let command = DocCommands::Import {
-            doc: Some(doc.id()),
-            author: Some(author),
-            prefix: None,
-            path: temp_dir.path().to_string_lossy().into(),
-            in_place: false,
-            no_prompt: true,
-        };
+    //     let command = DocCommands::Import {
+    //         doc: Some(doc.id()),
+    //         author: Some(author),
+    //         prefix: None,
+    //         path: temp_dir.path().to_string_lossy().into(),
+    //         in_place: false,
+    //         no_prompt: true,
+    //     };
 
-        command
-            .run(&docs, &blobs, &cli)
-            .await
-            .context("DocCommands run")?;
+    //     command
+    //         .run(&docs, &blobs, &cli)
+    //         .await
+    //         .context("DocCommands run")?;
 
-        let keys: Vec<_> = doc
-            .get_many(Query::all())
-            .await
-            .context("doc get many")?
-            .try_collect()
-            .await?;
-        assert_eq!(2, keys.len());
+    //     let keys: Vec<_> = doc
+    //         .get_many(Query::all())
+    //         .await
+    //         .context("doc get many")?
+    //         .try_collect()
+    //         .await?;
+    //     assert_eq!(2, keys.len());
 
-        // todo
-        // iroh.shutdown(false).await?;
-        Ok(())
-    }
+    //     // todo
+    //     // iroh.shutdown(false).await?;
+    //     Ok(())
+    // }
 }

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -127,11 +127,18 @@ impl<S: BlobStore> Builder<S> {
         let mut builder = iroh::Endpoint::builder()
             .bind_addr_v4(addr_v4)
             .bind_addr_v6(addr_v6)
-            .discovery_n0()
             .relay_mode(self.relay_mode.clone())
             .insecure_skip_relay_cert_verify(self.insecure_skip_relay_cert_verify);
         if let Some(dns_resolver) = self.dns_resolver.clone() {
             builder = builder.dns_resolver(dns_resolver);
+        }
+        if let Some(secret_key) = self.secret_key {
+            builder = builder.secret_key(secret_key);
+        }
+        if let Some(discovery) = self.node_discovery {
+            builder = builder.discovery(discovery);
+        } else {
+            builder = builder.discovery_n0();
         }
         let endpoint = builder.bind().await?;
         let mut router = iroh::protocol::Router::builder(endpoint.clone());


### PR DESCRIPTION
## Description

- Comments out a test that has `todo!()` and was `#[ignore]`d, but ran in the flaky test action.
- Fixes the `Node` builder so it actually uses `self.node_discovery` and `self.secret_key` when set.

## Change checklist

- [x] Self-review.
- [x] Tests if relevant.
