### PR TITLE
chore: patch to use main branch of iroh dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2150,7 +2150,7 @@ dependencies = [
 [[package]]
 name = "iroh-blobs"
 version = "0.34.1"
-source = "git+https://github.com/n0-computer/iroh-blobs.git?branch=main#0308a77f9bc949a6f75750b514cdb99cfc1143f7"
+source = "git+https://github.com/n0-computer/iroh-blobs.git?branch=patch-iroh-main#2578c438dd01f4363dd848cd48932e6986cf00b0"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -2258,7 +2258,7 @@ dependencies = [
 [[package]]
 name = "iroh-gossip"
 version = "0.34.1"
-source = "git+https://github.com/n0-computer/iroh-gossip.git?branch=main#2a372144b08f6db43f67536e8694659b4b326698"
+source = "git+https://github.com/n0-computer/iroh-gossip.git?branch=patch-iroh-main#963ff20da4aad33b55ce41c9eeaad562da4f80b1"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -3626,7 +3626,7 @@ dependencies = [
 [[package]]
 name = "quic-rpc"
 version = "0.19.0"
-source = "git+https://github.com/n0-computer/quic-rpc.git?branch=main#3e2b3ee982c934ecb3527bb163be4a8570f62483"
+source = "git+https://github.com/n0-computer/quic-rpc.git?branch=patch-iroh-main#7211bf5ccadc2c80fc107e1b6ff093ac27eda85a"
 dependencies = [
  "anyhow",
  "document-features",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ rustdoc-args = ["--cfg", "iroh_docsrs"]
 
 [patch.crates-io]
 iroh = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }
-quic-rpc = { git = "https://github.com/n0-computer/quic-rpc.git", branch = "main" }
+quic-rpc = { git = "https://github.com/n0-computer/quic-rpc.git", branch = "patch-iroh-main" }
 iroh-base = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }
-iroh-gossip = { git = "https://github.com/n0-computer/iroh-gossip.git", branch = "main" }
-iroh-blobs = { git = "https://github.com/n0-computer/iroh-blobs.git", branch = "main" }
+iroh-gossip = { git = "https://github.com/n0-computer/iroh-gossip.git", branch = "patch-iroh-main" }
+iroh-blobs = { git = "https://github.com/n0-computer/iroh-blobs.git", branch = "patch-iroh-main" }

--- a/deny.toml
+++ b/deny.toml
@@ -1,40 +1,46 @@
-[bans]
-multiple-versions = "allow"
-deny = [
-     "aws-lc",
-     "aws-lc-rs",
-     "aws-lc-sys",
-     "native-tls",
-     "openssl",
+[advisories]
+ignore = [
+    "RUSTSEC-2024-0370",
+    "RUSTSEC-2024-0384",
+    "RUSTSEC-2024-0436",
 ]
+
+[bans]
+deny = [
+    "aws-lc",
+    "aws-lc-rs",
+    "aws-lc-sys",
+    "native-tls",
+    "openssl",
+]
+multiple-versions = "allow"
 
 [licenses]
 allow = [
-      "Apache-2.0",
-      "Apache-2.0 WITH LLVM-exception",
-      "BSD-2-Clause",
-      "BSD-3-Clause",
-      "BSL-1.0", # BOSL license
-      "ISC",
-      "MIT",
-      "Zlib",
-      "MPL-2.0", # https://fossa.com/blog/open-source-software-licenses-101-mozilla-public-license-2-0/
-      "Unicode-3.0"
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "ISC",
+    "MIT",
+    "Zlib",
+    "MPL-2.0",
+    "Unicode-3.0",
 ]
 
 [[licenses.clarify]]
-name = "ring"
 expression = "MIT AND ISC AND OpenSSL"
-license-files = [
-      { path = "LICENSE", hash = 0xbd0eed23 },
-]
+name = "ring"
 
-[advisories]
-ignore = [
-      "RUSTSEC-2024-0370", # unmaintained, no upgrade available
-      "RUSTSEC-2024-0384", # unmaintained, no upgrade available
-      "RUSTSEC-2024-0436", # paste
-]
+[[licenses.clarify.license-files]]
+hash = 3171872035
+path = "LICENSE"
 
 [sources]
-allow-git = []
+allow-git = [
+    "https://github.com/n0-computer/iroh-blobs.git",
+    "https://github.com/n0-computer/quic-rpc.git",
+    "https://github.com/n0-computer/iroh.git",
+    "https://github.com/n0-computer/iroh-gossip.git",
+]

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -160,7 +160,7 @@ impl<S: BlobStore> Builder<S> {
         router = router.accept(iroh_gossip::ALPN, gossip.clone());
 
         // Build the router
-        let router = router.spawn().await?;
+        let router = router.spawn();
 
         // Setup RPC
         let (internal_rpc, controller) =


### PR DESCRIPTION
This PR updates the following dependencies to use their main branches:

- `iroh` from `https://github.com/n0-computer/iroh.git`
- `quic-rpc` from `https://github.com/n0-computer/quic-rpc.git`
- `iroh-base` from `https://github.com/n0-computer/iroh.git`
- `iroh-gossip` from `https://github.com/n0-computer/iroh-gossip.git`
- `iroh-blobs` from `https://github.com/n0-computer/iroh-blobs.git`