### PR TITLE
chore: clippy fixes

### DIFF
--- a/src/heads.rs
+++ b/src/heads.rs
@@ -61,7 +61,7 @@ impl AuthorHeads {
     }
 
     /// Create an iterator over the entries in this state.
-    pub fn iter(&self) -> std::collections::btree_map::Iter<AuthorId, Timestamp> {
+    pub fn iter(&self) -> std::collections::btree_map::Iter<'_, AuthorId, Timestamp> {
         self.heads.iter()
     }
 

--- a/src/store/fs/bounds.rs
+++ b/src/store/fs/bounds.rs
@@ -61,8 +61,8 @@ impl RecordsBounds {
         Self::new(start, Self::namespace_end(ns))
     }
 
-    pub fn as_ref(&self) -> (Bound<RecordsId>, Bound<RecordsId>) {
-        fn map(id: &RecordsIdOwned) -> RecordsId {
+    pub fn as_ref(&self) -> (Bound<RecordsId<'_>>, Bound<RecordsId<'_>>) {
+        fn map(id: &RecordsIdOwned) -> RecordsId<'_> {
             (&id.0, &id.1, &id.2[..])
         }
         (map_bound(&self.0, map), map_bound(&self.1, map))
@@ -139,8 +139,8 @@ impl ByKeyBounds {
         Self(start, end)
     }
 
-    pub fn as_ref(&self) -> (Bound<RecordsByKeyId>, Bound<RecordsByKeyId>) {
-        fn map(id: &RecordsByKeyIdOwned) -> RecordsByKeyId {
+    pub fn as_ref(&self) -> (Bound<RecordsByKeyId<'_>>, Bound<RecordsByKeyId<'_>>) {
+        fn map(id: &RecordsByKeyIdOwned) -> RecordsByKeyId<'_> {
             (&id.0, &id.1[..], &id.2)
         }
         (map_bound(&self.0, map), map_bound(&self.1, map))

--- a/src/store/fs/tables.rs
+++ b/src/store/fs/tables.rs
@@ -96,7 +96,7 @@ impl TransactionAndTables {
         })
     }
 
-    pub fn tables(&self) -> &Tables {
+    pub fn tables(&self) -> &Tables<'_> {
         self.inner.borrow_dependent()
     }
 


### PR DESCRIPTION
## Description

* Fixes for clippy 1.89
* Quite a few methods in the ranger::Store trait are unused outside of tests. This fixes this partially. The trait was used more before we made the redb store the only store (and the "memory" store now is the "fs" store with the in-memory redb backend). This should be revisited properly, i.e. actually remove the things that are not needed anymore.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
