### PR TITLE
tests: add test about rejoining a document

### DIFF
--- a/src/actor.rs
+++ b/src/actor.rs
@@ -993,7 +993,6 @@ impl OpenReplicas {
             }
             hash_map::Entry::Occupied(mut e) => {
                 let state = e.get_mut();
-                tracing::debug!("STATE {state:?}");
                 state.handles = state.handles.wrapping_sub(1);
                 if state.handles == 0 {
                     let _ = e.remove_entry();


### PR DESCRIPTION
## Description

This adds an integration test that tries to model the situation outlined in #51. The test passes.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
