### PR TITLE
feat: build on wasm

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+[target.wasm32-unknown-unknown]
+runner = "wasm-bindgen-test-runner"
+rustflags = ['--cfg', 'getrandom_backend="wasm_js"']

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -279,3 +279,40 @@ jobs:
     - uses: actions/checkout@v4
     - run: pip install --user codespell[toml]
     - run: codespell --ignore-words-list=ans,atmost,crate,inout,ratatui,ser,stayin,swarmin,worl --skip=CHANGELOG.md
+
+  wasm_build:
+    name: Build & test wasm32
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: '--cfg getrandom_backend="wasm_js"'
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Add wasm target
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: Install wasm-tools
+        uses: bytecodealliance/actions/wasm-tools/setup@v1
+
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-bindgen,wasm-pack
+
+      - name: wasm32 build
+        run: cargo build --target wasm32-unknown-unknown --no-default-features
+
+      # If the Wasm file contains any 'import "env"' declarations, then
+      # some non-Wasm-compatible code made it into the final code.
+      - name: Ensure no 'import "env"' in wasm
+        run: |
+          ! wasm-tools print --skeleton target/wasm32-unknown-unknown/debug/iroh_docs.wasm | grep 'import "env"'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    types: [ 'labeled', 'unlabeled', 'opened', 'synchronize', 'reopened' ]
+    types: ["labeled", "unlabeled", "opened", "synchronize", "reopened"]
   merge_group:
   push:
     branches:
@@ -24,7 +24,7 @@ jobs:
   tests:
     name: CI Test Suite
     if: "github.event_name != 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'flaky-test')"
-    uses: './.github/workflows/tests.yaml'
+    uses: "./.github/workflows/tests.yaml"
 
   cross_build:
     name: Cross Build Only
@@ -35,8 +35,8 @@ jobs:
       fail-fast: false
       matrix:
         target:
-           # cross tests are currently broken vor armv7 and aarch64
-           # see https://github.com/cross-rs/cross/issues/1311
+          # cross tests are currently broken vor armv7 and aarch64
+          # see https://github.com/cross-rs/cross/issues/1311
           # - armv7-linux-androideabi
           # - aarch64-linux-android
           # Freebsd execution fails in cross
@@ -45,29 +45,29 @@ jobs:
           # Netbsd execution fails to link in cross
           # - x86_64-unknown-netbsd
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        submodules: recursive
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
-    - name: Install rust stable
-      uses: dtolnay/rust-toolchain@stable
+      - name: Install rust stable
+        uses: dtolnay/rust-toolchain@stable
 
-    - name: Cleanup Docker
-      continue-on-error: true
-      run: |
-        docker kill $(docker ps -q)
+      - name: Cleanup Docker
+        continue-on-error: true
+        run: |
+          docker kill $(docker ps -q)
 
-      # See https://github.com/cross-rs/cross/issues/1222
-    - uses: taiki-e/install-action@cross
+        # See https://github.com/cross-rs/cross/issues/1222
+      - uses: taiki-e/install-action@cross
 
-    - name: build
-      # cross tests are currently broken vor armv7 and aarch64
-      # see https://github.com/cross-rs/cross/issues/1311.  So on
-      # those platforms we only build but do not run tests.
-      run: cross build --all --target ${{ matrix.target }}
-      env:
-        RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
+      - name: build
+        # cross tests are currently broken vor armv7 and aarch64
+        # see https://github.com/cross-rs/cross/issues/1311.  So on
+        # those platforms we only build but do not run tests.
+        run: cross build --all --target ${{ matrix.target }}
+        env:
+          RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
 
   android_build:
     name: Android Build Only
@@ -82,38 +82,38 @@ jobs:
           - aarch64-linux-android
           - armv7-linux-androideabi
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Set up Rust
-      uses: dtolnay/rust-toolchain@stable
-      with:
-        target: ${{ matrix.target }}
-    - name: Install rustup target
-      run: rustup target add ${{ matrix.target }}
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          target: ${{ matrix.target }}
+      - name: Install rustup target
+        run: rustup target add ${{ matrix.target }}
 
-    - name: Setup Java
-      uses: actions/setup-java@v4
-      with:
-        distribution: 'temurin'
-        java-version: '17'
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "17"
 
-    - name: Setup Android SDK
-      uses: android-actions/setup-android@v3
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
 
-    - name: Setup Android NDK
-      uses: arqu/setup-ndk@main
-      id: setup-ndk
-      with:
-        ndk-version: r23
-        add-to-path: true
+      - name: Setup Android NDK
+        uses: arqu/setup-ndk@main
+        id: setup-ndk
+        with:
+          ndk-version: r23
+          add-to-path: true
 
-    - name: Build
-      env:
-        ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
-      run: |
-        cargo install --version 3.5.4 cargo-ndk
-        cargo ndk --target ${{ matrix.target }} build
+      - name: Build
+        env:
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
+        run: |
+          cargo install --version 3.5.4 cargo-ndk
+          cargo ndk --target ${{ matrix.target }} build
 
   cross_test:
     name: Cross Test
@@ -126,26 +126,26 @@ jobs:
         target:
           - i686-unknown-linux-gnu
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        submodules: recursive
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
-    - name: Install rust stable
-      uses: dtolnay/rust-toolchain@stable
+      - name: Install rust stable
+        uses: dtolnay/rust-toolchain@stable
 
-    - name: Cleanup Docker
-      continue-on-error: true
-      run: |
-        docker kill $(docker ps -q)
+      - name: Cleanup Docker
+        continue-on-error: true
+        run: |
+          docker kill $(docker ps -q)
 
-      # See https://github.com/cross-rs/cross/issues/1222
-    - uses: taiki-e/install-action@cross
+        # See https://github.com/cross-rs/cross/issues/1222
+      - uses: taiki-e/install-action@cross
 
-    - name: test
-      run: cross test --all --target ${{ matrix.target }} -- --test-threads=12
-      env:
-        RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG' }}
+      - name: test
+        run: cross test --all --target ${{ matrix.target }} -- --test-threads=12
+        env:
+          RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG' }}
 
   check_semver:
     runs-on: ubuntu-latest
@@ -186,13 +186,13 @@ jobs:
       RUSTC_WRAPPER: "sccache"
       SCCACHE_GHA_ENABLED: "on"
     steps:
-    - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@stable
-      with:
-        components: rustfmt
-    - uses: mozilla-actions/sccache-action@v0.0.9
-    - uses: taiki-e/install-action@cargo-make
-    - run: cargo make format-check
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: taiki-e/install-action@cargo-make
+      - run: cargo make format-check
 
   check_docs:
     timeout-minutes: 30
@@ -202,17 +202,17 @@ jobs:
       RUSTC_WRAPPER: "sccache"
       SCCACHE_GHA_ENABLED: "on"
     steps:
-    - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@master
-      with:
-        toolchain: nightly-2025-10-09
-    - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2025-10-09
+      - name: Install sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
 
-    - name: Docs
-      run: cargo doc --workspace --all-features --no-deps --document-private-items
-      env:
-        RUSTDOCFLAGS: --cfg docsrs
+      - name: Docs
+        run: cargo doc --workspace --all-features --no-deps --document-private-items
+        env:
+          RUSTDOCFLAGS: --cfg docsrs
 
   clippy_check:
     timeout-minutes: 30
@@ -221,23 +221,23 @@ jobs:
       RUSTC_WRAPPER: "sccache"
       SCCACHE_GHA_ENABLED: "on"
     steps:
-    - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@stable
-      with:
-        components: clippy
-    - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - name: Install sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
 
-    # TODO: We have a bunch of platform-dependent code so should
-    #    probably run this job on the full platform matrix
-    - name: clippy check (all features)
-      run: cargo clippy --workspace --all-features --all-targets --bins --tests --benches
+      # TODO: We have a bunch of platform-dependent code so should
+      #    probably run this job on the full platform matrix
+      - name: clippy check (all features)
+        run: cargo clippy --workspace --all-features --all-targets --bins --tests --benches
 
-    - name: clippy check (no features)
-      run: cargo clippy --workspace --no-default-features --lib --bins --tests
+      - name: clippy check (no features)
+        run: cargo clippy --workspace --no-default-features --lib --bins --tests
 
-    - name: clippy check (default features)
-      run: cargo clippy --workspace --all-targets
+      - name: clippy check (default features)
+        run: cargo clippy --workspace --all-targets
 
   msrv:
     if: "github.event_name != 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'flaky-test')"
@@ -248,17 +248,17 @@ jobs:
       RUSTC_WRAPPER: "sccache"
       SCCACHE_GHA_ENABLED: "on"
     steps:
-    - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@master
-      with:
-        toolchain: ${{ env.MSRV }}
-    - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.MSRV }}
+      - name: Install sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
 
-    - name: Check MSRV all features
-      continue-on-error: true
-      run: |
-        cargo +$MSRV check --workspace --all-targets
+      - name: Check MSRV all features
+        continue-on-error: true
+        run: |
+          cargo +$MSRV check --workspace --all-targets
 
   cargo_deny:
     timeout-minutes: 30
@@ -276,9 +276,9 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - run: pip install --user codespell[toml]
-    - run: codespell --ignore-words-list=ans,atmost,crate,inout,ratatui,ser,stayin,swarmin,worl --skip=CHANGELOG.md
+      - uses: actions/checkout@v4
+      - run: pip install --user codespell[toml]
+      - run: codespell --ignore-words-list=ans,atmost,crate,inout,ratatui,ser,stayin,swarmin,worl --skip=CHANGELOG.md
 
   wasm_build:
     name: Build & test wasm32

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1496,9 +1496,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
+checksum = "1744436df46f0bde35af3eda22aeaba453aada65d8f1c171cd8a5f59030bd69f"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1850,8 +1850,7 @@ dependencies = [
 [[package]]
 name = "iroh-blobs"
 version = "0.97.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c901304c1c28f257fcf9aae8c9149e54e0baf62f5eb2788cecde3bf1206a04e6"
+source = "git+https://github.com/n0-computer/iroh-blobs.git?branch=b5%2Ffix-std-time#74175f18714e24356e9fa9171fd36cb96777420e"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -2456,8 +2455,7 @@ dependencies = [
 [[package]]
 name = "n0-snafu"
 version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1815107e577a95bfccedb4cfabc73d709c0db6d12de3f14e0f284a8c5036dc4f"
+source = "git+https://github.com/n0-computer/n0-snafu.git?branch=b5%2Fwasm#fbee015d3789c8e7d86647399e9021f9e651d7d6"
 dependencies = [
  "anyhow",
  "btparse",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2408,8 +2408,6 @@ dependencies = [
 [[package]]
 name = "n0-future"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439e746b307c1fd0c08771c3cafcd1746c3ccdb0d9c7b859d3caded366b6da76"
 dependencies = [
  "cfg_aliases",
  "derive_more 1.0.0",
@@ -4746,6 +4744,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
+ "serde",
  "wasm-bindgen",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,7 +342,8 @@ dependencies = [
 [[package]]
 name = "bao-tree"
 version = "0.16.0"
-source = "git+https://github.com/n0-computer/bao-tree?branch=main#0d2e29163a52654ebf231e09ae87e4e207e21382"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06384416b1825e6e04fde63262fda2dc408f5b64c02d04e0d8b70ae72c17a52b"
 dependencies = [
  "blake3",
  "bytes",
@@ -1774,67 +1775,6 @@ dependencies = [
 
 [[package]]
 name = "iroh"
-version = "0.94.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9428cef1eafd2eac584269986d1949e693877ac12065b401dfde69f664b07ac"
-dependencies = [
- "aead",
- "backon",
- "bytes",
- "cfg_aliases",
- "crypto_box",
- "data-encoding",
- "derive_more 2.0.1",
- "ed25519-dalek",
- "futures-util",
- "getrandom 0.3.4",
- "hickory-resolver",
- "http",
- "igd-next",
- "instant",
- "iroh-base 0.94.1",
- "iroh-metrics 0.36.2",
- "iroh-quinn",
- "iroh-quinn-proto",
- "iroh-quinn-udp",
-<<<<<<< HEAD
- "iroh-relay 0.94.0",
-=======
- "iroh-relay",
->>>>>>> df4c3ab (remove path dep)
- "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "n0-snafu",
- "n0-watcher 0.4.0",
- "nested_enum_utils",
- "netdev",
- "netwatch 0.11.0",
- "pin-project",
- "pkarr",
- "pkcs8",
- "portmapper 0.11.0",
- "rand 0.9.2",
- "reqwest",
- "rustls",
- "rustls-pki-types",
- "rustls-platform-verifier",
- "rustls-webpki",
- "serde",
- "smallvec",
- "snafu",
- "strum 0.27.2",
- "time",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "tracing",
- "url",
- "wasm-bindgen-futures",
- "webpki-roots",
- "z32",
-]
-
-[[package]]
-name = "iroh"
 version = "0.95.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2374ba3cdaac152dc6ada92d971f7328e6408286faab3b7350842b2ebbed4789"
@@ -1854,21 +1794,21 @@ dependencies = [
  "http",
  "igd-next",
  "instant",
- "iroh-base 0.95.1",
+ "iroh-base",
  "iroh-metrics 0.37.0",
  "iroh-quinn",
  "iroh-quinn-proto",
  "iroh-quinn-udp",
- "iroh-relay 0.95.1",
+ "iroh-relay",
  "n0-error",
  "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "n0-watcher 0.5.0",
+ "n0-watcher",
  "netdev",
- "netwatch 0.12.0",
+ "netwatch",
  "pin-project",
  "pkarr",
  "pkcs8",
- "portmapper 0.12.0",
+ "portmapper",
  "rand 0.9.2",
  "reqwest",
  "rustls",
@@ -1887,26 +1827,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "webpki-roots",
  "z32",
-]
-
-[[package]]
-name = "iroh-base"
-version = "0.94.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7db6dfffe81a58daae02b72c7784c20feef5b5d3849b190ed1c96a8fa0b3cae8"
-dependencies = [
- "curve25519-dalek",
- "data-encoding",
- "derive_more 2.0.1",
- "ed25519-dalek",
- "n0-snafu",
- "nested_enum_utils",
- "rand_core 0.9.3",
- "serde",
- "snafu",
- "url",
- "zeroize",
- "zeroize_derive",
 ]
 
 [[package]]
@@ -1929,8 +1849,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-blobs"
-version = "0.96.0"
-source = "git+https://github.com/n0-computer/iroh-blobs?branch=Frando%2Fwasm-nopatch#c1243d2ba54edacd2c4633bc121640afde93aabf"
+version = "0.97.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c901304c1c28f257fcf9aae8c9149e54e0baf62f5eb2788cecde3bf1206a04e6"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -1943,17 +1864,14 @@ dependencies = [
  "futures-lite",
  "genawaiter",
  "hex",
- "iroh 0.94.0",
- "iroh-base 0.94.1",
+ "iroh",
+ "iroh-base",
  "iroh-io",
- "iroh-metrics 0.36.2",
+ "iroh-metrics 0.37.0",
  "iroh-quinn",
  "iroh-tickets",
-<<<<<<< HEAD
- "irpc 0.11.0",
-=======
- "irpc 0.10.0 (git+https://github.com/n0-computer/irpc?branch=main)",
->>>>>>> df4c3ab (remove path dep)
+ "irpc",
+ "n0-error",
  "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "n0-snafu",
  "nested_enum_utils",
@@ -1987,14 +1905,13 @@ dependencies = [
  "futures-lite",
  "futures-util",
  "hex",
- "iroh 0.94.0",
- "iroh 0.95.1",
+ "iroh",
  "iroh-blobs",
  "iroh-gossip",
  "iroh-metrics 0.36.2",
  "iroh-quinn",
  "iroh-tickets",
- "irpc 0.11.0",
+ "irpc",
  "n0-error",
  "n0-future 0.3.0 (git+https://github.com/n0-computer/n0-future?branch=main)",
  "nested_enum_utils",
@@ -2024,9 +1941,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-gossip"
-version = "0.94.0"
+version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f1b658eb51a96e1fe3d56dadb283fdc68fd11d8ac5d286838c6d2f62927293c"
+checksum = "026dd31b487ec5e80ac0240f4eb70cd6c0a2800f6ef44beca5329443c194bb22"
 dependencies = [
  "blake3",
  "bytes",
@@ -2038,24 +1955,15 @@ dependencies = [
  "futures-util",
  "hex",
  "indexmap",
-<<<<<<< HEAD
- "iroh 0.94.0",
- "iroh-base 0.94.1",
- "iroh-metrics 0.36.2",
- "irpc 0.10.0",
-=======
  "iroh",
  "iroh-base",
- "iroh-metrics",
- "irpc 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
->>>>>>> df4c3ab (remove path dep)
+ "iroh-metrics 0.37.0",
+ "irpc",
+ "n0-error",
  "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "n0-snafu",
- "nested_enum_utils",
  "postcard",
  "rand 0.9.2",
  "serde",
- "snafu",
  "tokio",
  "tokio-util",
  "tracing",
@@ -2190,55 +2098,6 @@ dependencies = [
 
 [[package]]
 name = "iroh-relay"
-version = "0.94.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "360e201ab1803201de9a125dd838f7a4d13e6ba3a79aeb46c7fbf023266c062e"
-dependencies = [
- "blake3",
- "bytes",
- "cfg_aliases",
- "data-encoding",
- "derive_more 2.0.1",
- "getrandom 0.3.4",
- "hickory-resolver",
- "http",
- "http-body-util",
- "hyper",
- "hyper-util",
- "iroh-base 0.94.1",
- "iroh-metrics 0.36.2",
- "iroh-quinn",
- "iroh-quinn-proto",
- "lru 0.16.2",
- "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "n0-snafu",
- "nested_enum_utils",
- "num_enum",
- "pin-project",
- "pkarr",
- "postcard",
- "rand 0.9.2",
- "reqwest",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_bytes",
- "sha1",
- "snafu",
- "strum 0.27.2",
- "tokio",
- "tokio-rustls",
- "tokio-util",
- "tokio-websockets",
- "tracing",
- "url",
- "webpki-roots",
- "ws_stream_wasm",
- "z32",
-]
-
-[[package]]
-name = "iroh-relay"
 version = "0.95.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43fbdf2aeffa7d6ede1a31f6570866c2199b1cee96a0b563994623795d1bac2c"
@@ -2257,20 +2116,13 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
- "iroh-base 0.95.1",
+ "iroh-base",
  "iroh-metrics 0.37.0",
  "iroh-quinn",
  "iroh-quinn-proto",
-<<<<<<< HEAD
  "lru 0.16.2",
  "n0-error",
  "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
-=======
- "lru 0.16.1",
- "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "n0-snafu",
- "nested_enum_utils",
->>>>>>> df4c3ab (remove path dep)
  "num_enum",
  "pin-project",
  "pkarr",
@@ -2306,54 +2158,29 @@ dependencies = [
 
 [[package]]
 name = "iroh-tickets"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7683c7819693eb8b3d61d1d45ffa92e2faeb07762eb0c3debb50ad795538d221"
+checksum = "1a322053cacddeca222f0999ce3cf6aa45c64ae5ad8c8911eac9b66008ffbaa5"
 dependencies = [
  "data-encoding",
  "derive_more 2.0.1",
- "iroh-base 0.94.1",
- "n0-snafu",
- "nested_enum_utils",
+ "iroh-base",
+ "n0-error",
  "postcard",
  "serde",
- "snafu",
-]
-
-[[package]]
-name = "irpc"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52cf44fdb253f2a3e22e5ecfa8efa466929f8b7cdd4fc0f958f655406e8cdab6"
-dependencies = [
- "futures-util",
-<<<<<<< HEAD
- "irpc-derive 0.8.0",
-=======
- "irpc-derive 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
->>>>>>> df4c3ab (remove path dep)
- "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde",
- "thiserror 2.0.17",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
 name = "irpc"
 version = "0.11.0"
-source = "git+https://github.com/n0-computer/irpc?branch=main#732a57fc26689da87fd5078442fc33bc54e4001c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bee97aaa18387c4f0aae61058195dc9f9dea3e41c0e272973fe3e9bf611563d"
 dependencies = [
  "futures-buffered",
  "futures-util",
  "iroh-quinn",
-<<<<<<< HEAD
- "irpc-derive 0.9.0",
+ "irpc-derive",
  "n0-error",
-=======
- "irpc-derive 0.8.0 (git+https://github.com/n0-computer/irpc?branch=main)",
->>>>>>> df4c3ab (remove path dep)
  "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "postcard",
  "rcgen",
@@ -2367,19 +2194,9 @@ dependencies = [
 
 [[package]]
 name = "irpc-derive"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "969df6effc474e714fb7e738eb9859aa22f40dc2280cadeab245817075c7f273"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.110",
-]
-
-[[package]]
-name = "irpc-derive"
 version = "0.9.0"
-source = "git+https://github.com/n0-computer/irpc?branch=main#732a57fc26689da87fd5078442fc33bc54e4001c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58148196d2230183c9679431ac99b57e172000326d664e8456fa2cd27af6505a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2597,6 +2414,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a4839a11b62f1fdd75be912ee20634053c734c2240e867ded41c7f50822c549"
 dependencies = [
+ "anyhow",
  "derive_more 2.0.1",
  "n0-error-macros",
  "spez",
@@ -2666,17 +2484,6 @@ dependencies = [
  "color-backtrace",
  "snafu",
  "tracing-error",
-]
-
-[[package]]
-name = "n0-watcher"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34c65e127e06e5a2781b28df6a33ea474a7bddc0ac0cfea888bd20c79a1b6516"
-dependencies = [
- "derive_more 2.0.1",
- "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "snafu",
 ]
 
 [[package]]
@@ -2769,45 +2576,6 @@ dependencies = [
 
 [[package]]
 name = "netwatch"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98d7ec7abdbfe67ee70af3f2002326491178419caea22254b9070e6ff0c83491"
-dependencies = [
- "atomic-waker",
- "bytes",
- "cfg_aliases",
- "derive_more 2.0.1",
- "iroh-quinn-udp",
- "js-sys",
- "libc",
- "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
-<<<<<<< HEAD
- "n0-watcher 0.4.0",
-=======
- "n0-watcher",
->>>>>>> df4c3ab (remove path dep)
- "nested_enum_utils",
- "netdev",
- "netlink-packet-core",
- "netlink-packet-route",
- "netlink-proto",
- "netlink-sys",
- "pin-project-lite",
- "serde",
- "snafu",
- "socket2 0.6.1",
- "time",
- "tokio",
- "tokio-util",
- "tracing",
- "web-sys",
- "windows 0.62.2",
- "windows-result 0.4.1",
- "wmi",
-]
-
-[[package]]
-name = "netwatch"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26f2acd376ef48b6c326abf3ba23c449e0cb8aa5c2511d189dd8a8a3bfac889b"
@@ -2821,7 +2589,7 @@ dependencies = [
  "libc",
  "n0-error",
  "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "n0-watcher 0.5.0",
+ "n0-watcher",
  "netdev",
  "netlink-packet-core",
  "netlink-packet-route",
@@ -3140,37 +2908,6 @@ checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "portmapper"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d73aa9bd141e0ff6060fea89a5437883f3b9ceea1cda71c790b90e17d072a3b3"
-dependencies = [
- "base64",
- "bytes",
- "derive_more 2.0.1",
- "futures-lite",
- "futures-util",
- "hyper-util",
- "igd-next",
- "iroh-metrics 0.36.2",
- "libc",
- "nested_enum_utils",
- "netwatch 0.11.0",
- "num_enum",
- "rand 0.9.2",
- "serde",
- "smallvec",
- "snafu",
- "socket2 0.6.1",
- "time",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "portmapper"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b575f975dcf03e258b0c7ab3f81497d7124f508884c37da66a7314aa2a8d467"
@@ -3185,7 +2922,7 @@ dependencies = [
  "iroh-metrics 0.37.0",
  "libc",
  "n0-error",
- "netwatch 0.12.0",
+ "netwatch",
  "num_enum",
  "rand 0.9.2",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.110",
  "synstructure",
 ]
 
@@ -178,7 +178,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -214,7 +214,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -424,9 +424,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.11.0-rc.5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9ef36a6fcdb072aa548f3da057640ec10859eb4e91ddf526ee648d50c76a949"
+checksum = "96eb4cdd6cf1b31d671e9efe75c5d1ec614776856cefbe109ca373554a6d514f"
 dependencies = [
  "hybrid-array",
  "zeroize",
@@ -492,9 +492,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.44"
+version = "1.2.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37521ac7aabe3d13122dc382493e20c9416f299d2ccd5b3a5340a2570cdeb0f3"
+checksum = "35900b6c8d709fb1d854671ae27aeaa9eec2f8b01b364e1619a40da3e6fe2afe"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -587,7 +587,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -796,7 +796,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -821,9 +821,9 @@ checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "der"
-version = "0.8.0-rc.9"
+version = "0.8.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9d8dd2f26c86b27a2a8ea2767ec7f9df7a89516e4794e54ac01ee618dda3aa4"
+checksum = "02c1d73e9668ea6b6a28172aa55f3ebec38507131ce179051c8033b5c6037653"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -862,7 +862,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -891,7 +891,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.110",
  "unicode-xid",
 ]
 
@@ -903,7 +903,7 @@ checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.110",
  "unicode-xid",
 ]
 
@@ -932,7 +932,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -963,9 +963,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ed25519"
-version = "3.0.0-rc.1"
+version = "3.0.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ef49c0b20c0ad088893ad2a790a29c06a012b3f05bcfc66661fd22a94b32129"
+checksum = "594435fe09e345ee388e4e8422072ff7dfeca8729389fbd997b3f5504c44cd47"
 dependencies = [
  "pkcs8",
  "serde",
@@ -1009,7 +1009,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1191,7 +1191,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2010,7 +2010,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2172,7 +2172,7 @@ checksum = "58148196d2230183c9679431ac99b57e172000326d664e8456fa2cd27af6505a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2401,7 +2401,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2458,7 +2458,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2656,7 +2656,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2746,9 +2746,9 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "1.0.0-rc.3"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8e58fab693c712c0d4e88f8eb3087b6521d060bcaf76aeb20cb192d809115ba"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
 dependencies = [
  "base64ct",
 ]
@@ -2786,7 +2786,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2834,9 +2834,9 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.11.0-rc.7"
+version = "0.11.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93eac55f10aceed84769df670ea4a32d2ffad7399400d41ee1c13b1cd8e1b478"
+checksum = "77089aec8290d0b7bb01b671b091095cf1937670725af4fd73d47249f03b12c0"
 dependencies = [
  "der",
  "spki",
@@ -2920,7 +2920,7 @@ checksum = "e0232bd009a197ceec9cc881ba46f727fcd8060a2d8d6a9dde7a69030a6fe2bb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -3079,9 +3079,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.41"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
@@ -3222,7 +3222,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -3649,7 +3649,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -3814,7 +3814,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -3845,7 +3845,7 @@ checksum = "c87e960f4dca2788eeb86bbdde8dd246be8948790b7618d656e68f9b720a86e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -3894,7 +3894,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -3905,7 +3905,7 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -3936,7 +3936,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -3948,7 +3948,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -3970,9 +3970,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.109"
+version = "2.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f17c7e013e88258aa9543dcbe81aca68a667a9ac37cd69c9fbc07858bfe0e2f"
+checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4007,7 +4007,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -4083,7 +4083,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -4132,7 +4132,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -4143,7 +4143,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -4236,7 +4236,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -4442,7 +4442,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -4512,7 +4512,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -4702,7 +4702,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.110",
  "wasm-bindgen-shared",
 ]
 
@@ -4922,7 +4922,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -4933,7 +4933,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -5445,7 +5445,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.110",
  "synstructure",
 ]
 
@@ -5472,7 +5472,7 @@ checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -5492,7 +5492,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.110",
  "synstructure",
 ]
 
@@ -5513,7 +5513,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -5546,5 +5546,5 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.109",
+ "syn 2.0.110",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4505,6 +4505,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4514,12 +4524,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1897,6 +1897,7 @@ dependencies = [
  "async-channel",
  "blake3",
  "bytes",
+ "cfg_aliases",
  "data-encoding",
  "derive_more 2.0.1",
  "ed25519-dalek",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1801,7 +1801,7 @@ dependencies = [
  "iroh-quinn-udp",
  "iroh-relay",
  "n0-error",
- "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "n0-future",
  "n0-watcher",
  "netdev",
  "netwatch",
@@ -1872,7 +1872,7 @@ dependencies = [
  "iroh-tickets",
  "irpc",
  "n0-error",
- "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "n0-future",
  "n0-snafu",
  "nested_enum_utils",
  "postcard",
@@ -1913,7 +1913,7 @@ dependencies = [
  "iroh-tickets",
  "irpc",
  "n0-error",
- "n0-future 0.3.0 (git+https://github.com/n0-computer/n0-future?branch=main)",
+ "n0-future",
  "nested_enum_utils",
  "num_enum",
  "parking_lot",
@@ -1960,7 +1960,7 @@ dependencies = [
  "iroh-metrics 0.37.0",
  "irpc",
  "n0-error",
- "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "n0-future",
  "postcard",
  "rand 0.9.2",
  "serde",
@@ -2122,7 +2122,7 @@ dependencies = [
  "iroh-quinn-proto",
  "lru 0.16.2",
  "n0-error",
- "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "n0-future",
  "num_enum",
  "pin-project",
  "pkarr",
@@ -2181,7 +2181,7 @@ dependencies = [
  "iroh-quinn",
  "irpc-derive",
  "n0-error",
- "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "n0-future",
  "postcard",
  "rcgen",
  "rustls",
@@ -2434,29 +2434,9 @@ dependencies = [
 
 [[package]]
 name = "n0-future"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439e746b307c1fd0c08771c3cafcd1746c3ccdb0d9c7b859d3caded366b6da76"
-dependencies = [
- "cfg_aliases",
- "derive_more 1.0.0",
- "futures-buffered",
- "futures-lite",
- "futures-util",
- "js-sys",
- "pin-project",
- "send_wrapper",
- "tokio",
- "tokio-util",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-time",
-]
-
-[[package]]
-name = "n0-future"
-version = "0.3.0"
-source = "git+https://github.com/n0-computer/n0-future?branch=main#f5ea6ede1f468658fda2cbd7764b6679c8d2898c"
+checksum = "8c0709ac8235ce13b82bc4d180ee3c42364b90c1a8a628c3422d991d75a728b5"
 dependencies = [
  "cfg_aliases",
  "derive_more 1.0.0",
@@ -2494,7 +2474,7 @@ checksum = "38acf13c1ddafc60eb7316d52213467f8ccb70b6f02b65e7d97f7799b1f50be4"
 dependencies = [
  "derive_more 2.0.1",
  "n0-error",
- "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "n0-future",
 ]
 
 [[package]]
@@ -2588,7 +2568,7 @@ dependencies = [
  "js-sys",
  "libc",
  "n0-error",
- "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "n0-future",
  "n0-watcher",
  "netdev",
  "netlink-packet-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,8 +342,7 @@ dependencies = [
 [[package]]
 name = "bao-tree"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06384416b1825e6e04fde63262fda2dc408f5b64c02d04e0d8b70ae72c17a52b"
+source = "git+https://github.com/n0-computer/bao-tree?branch=main#0d2e29163a52654ebf231e09ae87e4e207e21382"
 dependencies = [
  "blake3",
  "bytes",
@@ -1775,6 +1774,63 @@ dependencies = [
 
 [[package]]
 name = "iroh"
+version = "0.94.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9428cef1eafd2eac584269986d1949e693877ac12065b401dfde69f664b07ac"
+dependencies = [
+ "aead",
+ "backon",
+ "bytes",
+ "cfg_aliases",
+ "crypto_box",
+ "data-encoding",
+ "derive_more 2.0.1",
+ "ed25519-dalek",
+ "futures-util",
+ "getrandom 0.3.4",
+ "hickory-resolver",
+ "http",
+ "igd-next",
+ "instant",
+ "iroh-base 0.94.1",
+ "iroh-metrics 0.36.2",
+ "iroh-quinn",
+ "iroh-quinn-proto",
+ "iroh-quinn-udp",
+ "iroh-relay 0.94.0",
+ "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "n0-snafu",
+ "n0-watcher 0.4.0",
+ "nested_enum_utils",
+ "netdev",
+ "netwatch 0.11.0",
+ "pin-project",
+ "pkarr",
+ "pkcs8",
+ "portmapper 0.11.0",
+ "rand 0.9.2",
+ "reqwest",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "rustls-webpki",
+ "serde",
+ "smallvec",
+ "snafu",
+ "strum 0.27.2",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "url",
+ "wasm-bindgen-futures",
+ "webpki-roots",
+ "z32",
+]
+
+[[package]]
+name = "iroh"
 version = "0.95.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2374ba3cdaac152dc6ada92d971f7328e6408286faab3b7350842b2ebbed4789"
@@ -1794,21 +1850,21 @@ dependencies = [
  "http",
  "igd-next",
  "instant",
- "iroh-base",
- "iroh-metrics",
+ "iroh-base 0.95.1",
+ "iroh-metrics 0.37.0",
  "iroh-quinn",
  "iroh-quinn-proto",
  "iroh-quinn-udp",
- "iroh-relay",
+ "iroh-relay 0.95.1",
  "n0-error",
- "n0-future",
- "n0-watcher",
+ "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "n0-watcher 0.5.0",
  "netdev",
- "netwatch",
+ "netwatch 0.12.0",
  "pin-project",
  "pkarr",
  "pkcs8",
- "portmapper",
+ "portmapper 0.12.0",
  "rand 0.9.2",
  "reqwest",
  "rustls",
@@ -1831,6 +1887,26 @@ dependencies = [
 
 [[package]]
 name = "iroh-base"
+version = "0.94.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7db6dfffe81a58daae02b72c7784c20feef5b5d3849b190ed1c96a8fa0b3cae8"
+dependencies = [
+ "curve25519-dalek",
+ "data-encoding",
+ "derive_more 2.0.1",
+ "ed25519-dalek",
+ "n0-snafu",
+ "nested_enum_utils",
+ "rand_core 0.9.3",
+ "serde",
+ "snafu",
+ "url",
+ "zeroize",
+ "zeroize_derive",
+]
+
+[[package]]
+name = "iroh-base"
 version = "0.95.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25a8c5fb1cc65589f0d7ab44269a76f615a8c4458356952c9b0ef1c93ea45ff8"
@@ -1849,9 +1925,8 @@ dependencies = [
 
 [[package]]
 name = "iroh-blobs"
-version = "0.97.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c901304c1c28f257fcf9aae8c9149e54e0baf62f5eb2788cecde3bf1206a04e6"
+version = "0.96.0"
+source = "git+https://github.com/n0-computer/iroh-blobs?branch=Frando%2Fwasm-nopatch#c1243d2ba54edacd2c4633bc121640afde93aabf"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -1864,15 +1939,14 @@ dependencies = [
  "futures-lite",
  "genawaiter",
  "hex",
- "iroh",
- "iroh-base",
+ "iroh 0.94.0",
+ "iroh-base 0.94.1",
  "iroh-io",
- "iroh-metrics",
+ "iroh-metrics 0.36.2",
  "iroh-quinn",
  "iroh-tickets",
- "irpc",
- "n0-error",
- "n0-future",
+ "irpc 0.11.0",
+ "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "n0-snafu",
  "nested_enum_utils",
  "postcard",
@@ -1905,15 +1979,16 @@ dependencies = [
  "futures-lite",
  "futures-util",
  "hex",
- "iroh",
+ "iroh 0.94.0",
+ "iroh 0.95.1",
  "iroh-blobs",
  "iroh-gossip",
- "iroh-metrics",
+ "iroh-metrics 0.36.2",
  "iroh-quinn",
  "iroh-tickets",
- "irpc",
+ "irpc 0.11.0",
  "n0-error",
- "n0-future",
+ "n0-future 0.3.0 (git+https://github.com/n0-computer/n0-future?branch=main)",
  "nested_enum_utils",
  "num_enum",
  "parking_lot",
@@ -1941,9 +2016,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-gossip"
-version = "0.95.0"
+version = "0.94.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "026dd31b487ec5e80ac0240f4eb70cd6c0a2800f6ef44beca5329443c194bb22"
+checksum = "6f1b658eb51a96e1fe3d56dadb283fdc68fd11d8ac5d286838c6d2f62927293c"
 dependencies = [
  "blake3",
  "bytes",
@@ -1955,15 +2030,17 @@ dependencies = [
  "futures-util",
  "hex",
  "indexmap",
- "iroh",
- "iroh-base",
- "iroh-metrics",
- "irpc",
- "n0-error",
- "n0-future",
+ "iroh 0.94.0",
+ "iroh-base 0.94.1",
+ "iroh-metrics 0.36.2",
+ "irpc 0.10.0",
+ "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "n0-snafu",
+ "nested_enum_utils",
  "postcard",
  "rand 0.9.2",
  "serde",
+ "snafu",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1984,6 +2061,21 @@ dependencies = [
 
 [[package]]
 name = "iroh-metrics"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c84c167b59ae22f940e78eb347ca5f02aa25608e994cb5a7cc016ac2d5eada18"
+dependencies = [
+ "iroh-metrics-derive 0.3.1",
+ "itoa",
+ "postcard",
+ "ryu",
+ "serde",
+ "snafu",
+ "tracing",
+]
+
+[[package]]
+name = "iroh-metrics"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79e3381da7c93c12d353230c74bba26131d1c8bf3a4d8af0fec041546454582e"
@@ -1991,7 +2083,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
- "iroh-metrics-derive",
+ "iroh-metrics-derive 0.4.0",
  "itoa",
  "n0-error",
  "postcard",
@@ -2000,6 +2092,18 @@ dependencies = [
  "serde",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "iroh-metrics-derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "748d380f26f7c25307c0a7acd181b84b977ddc2a1b7beece1e5998623c323aa1"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2071,6 +2175,55 @@ dependencies = [
 
 [[package]]
 name = "iroh-relay"
+version = "0.94.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "360e201ab1803201de9a125dd838f7a4d13e6ba3a79aeb46c7fbf023266c062e"
+dependencies = [
+ "blake3",
+ "bytes",
+ "cfg_aliases",
+ "data-encoding",
+ "derive_more 2.0.1",
+ "getrandom 0.3.4",
+ "hickory-resolver",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "iroh-base 0.94.1",
+ "iroh-metrics 0.36.2",
+ "iroh-quinn",
+ "iroh-quinn-proto",
+ "lru 0.16.2",
+ "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "n0-snafu",
+ "nested_enum_utils",
+ "num_enum",
+ "pin-project",
+ "pkarr",
+ "postcard",
+ "rand 0.9.2",
+ "reqwest",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_bytes",
+ "sha1",
+ "snafu",
+ "strum 0.27.2",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tokio-websockets",
+ "tracing",
+ "url",
+ "webpki-roots",
+ "ws_stream_wasm",
+ "z32",
+]
+
+[[package]]
+name = "iroh-relay"
 version = "0.95.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43fbdf2aeffa7d6ede1a31f6570866c2199b1cee96a0b563994623795d1bac2c"
@@ -2089,13 +2242,13 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
- "iroh-base",
- "iroh-metrics",
+ "iroh-base 0.95.1",
+ "iroh-metrics 0.37.0",
  "iroh-quinn",
  "iroh-quinn-proto",
  "lru 0.16.2",
  "n0-error",
- "n0-future",
+ "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_enum",
  "pin-project",
  "pkarr",
@@ -2131,30 +2284,47 @@ dependencies = [
 
 [[package]]
 name = "iroh-tickets"
-version = "0.2.0"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a322053cacddeca222f0999ce3cf6aa45c64ae5ad8c8911eac9b66008ffbaa5"
+checksum = "7683c7819693eb8b3d61d1d45ffa92e2faeb07762eb0c3debb50ad795538d221"
 dependencies = [
  "data-encoding",
  "derive_more 2.0.1",
- "iroh-base",
- "n0-error",
+ "iroh-base 0.94.1",
+ "n0-snafu",
+ "nested_enum_utils",
  "postcard",
  "serde",
+ "snafu",
+]
+
+[[package]]
+name = "irpc"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cf44fdb253f2a3e22e5ecfa8efa466929f8b7cdd4fc0f958f655406e8cdab6"
+dependencies = [
+ "futures-util",
+ "irpc-derive 0.8.0",
+ "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
 name = "irpc"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bee97aaa18387c4f0aae61058195dc9f9dea3e41c0e272973fe3e9bf611563d"
+source = "git+https://github.com/n0-computer/irpc?branch=main#732a57fc26689da87fd5078442fc33bc54e4001c"
 dependencies = [
  "futures-buffered",
  "futures-util",
  "iroh-quinn",
- "irpc-derive",
+ "irpc-derive 0.9.0",
  "n0-error",
- "n0-future",
+ "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "postcard",
  "rcgen",
  "rustls",
@@ -2167,9 +2337,19 @@ dependencies = [
 
 [[package]]
 name = "irpc-derive"
-version = "0.9.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58148196d2230183c9679431ac99b57e172000326d664e8456fa2cd27af6505a"
+checksum = "969df6effc474e714fb7e738eb9859aa22f40dc2280cadeab245817075c7f273"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
+]
+
+[[package]]
+name = "irpc-derive"
+version = "0.9.0"
+source = "git+https://github.com/n0-computer/irpc?branch=main#732a57fc26689da87fd5078442fc33bc54e4001c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2387,7 +2567,6 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a4839a11b62f1fdd75be912ee20634053c734c2240e867ded41c7f50822c549"
 dependencies = [
- "anyhow",
  "derive_more 2.0.1",
  "n0-error-macros",
  "spez",
@@ -2408,6 +2587,28 @@ dependencies = [
 [[package]]
 name = "n0-future"
 version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439e746b307c1fd0c08771c3cafcd1746c3ccdb0d9c7b859d3caded366b6da76"
+dependencies = [
+ "cfg_aliases",
+ "derive_more 1.0.0",
+ "futures-buffered",
+ "futures-lite",
+ "futures-util",
+ "js-sys",
+ "pin-project",
+ "send_wrapper",
+ "tokio",
+ "tokio-util",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
+name = "n0-future"
+version = "0.3.0"
+source = "git+https://github.com/n0-computer/n0-future?branch=main#f5ea6ede1f468658fda2cbd7764b6679c8d2898c"
 dependencies = [
  "cfg_aliases",
  "derive_more 1.0.0",
@@ -2439,13 +2640,24 @@ dependencies = [
 
 [[package]]
 name = "n0-watcher"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34c65e127e06e5a2781b28df6a33ea474a7bddc0ac0cfea888bd20c79a1b6516"
+dependencies = [
+ "derive_more 2.0.1",
+ "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snafu",
+]
+
+[[package]]
+name = "n0-watcher"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38acf13c1ddafc60eb7316d52213467f8ccb70b6f02b65e7d97f7799b1f50be4"
 dependencies = [
  "derive_more 2.0.1",
  "n0-error",
- "n0-future",
+ "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2527,6 +2739,41 @@ dependencies = [
 
 [[package]]
 name = "netwatch"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98d7ec7abdbfe67ee70af3f2002326491178419caea22254b9070e6ff0c83491"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "cfg_aliases",
+ "derive_more 2.0.1",
+ "iroh-quinn-udp",
+ "js-sys",
+ "libc",
+ "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "n0-watcher 0.4.0",
+ "nested_enum_utils",
+ "netdev",
+ "netlink-packet-core",
+ "netlink-packet-route",
+ "netlink-proto",
+ "netlink-sys",
+ "pin-project-lite",
+ "serde",
+ "snafu",
+ "socket2 0.6.1",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "web-sys",
+ "windows 0.62.2",
+ "windows-result 0.4.1",
+ "wmi",
+]
+
+[[package]]
+name = "netwatch"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26f2acd376ef48b6c326abf3ba23c449e0cb8aa5c2511d189dd8a8a3bfac889b"
@@ -2539,8 +2786,8 @@ dependencies = [
  "js-sys",
  "libc",
  "n0-error",
- "n0-future",
- "n0-watcher",
+ "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "n0-watcher 0.5.0",
  "netdev",
  "netlink-packet-core",
  "netlink-packet-route",
@@ -2859,6 +3106,37 @@ checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "portmapper"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d73aa9bd141e0ff6060fea89a5437883f3b9ceea1cda71c790b90e17d072a3b3"
+dependencies = [
+ "base64",
+ "bytes",
+ "derive_more 2.0.1",
+ "futures-lite",
+ "futures-util",
+ "hyper-util",
+ "igd-next",
+ "iroh-metrics 0.36.2",
+ "libc",
+ "nested_enum_utils",
+ "netwatch 0.11.0",
+ "num_enum",
+ "rand 0.9.2",
+ "serde",
+ "smallvec",
+ "snafu",
+ "socket2 0.6.1",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "portmapper"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b575f975dcf03e258b0c7ab3f81497d7124f508884c37da66a7314aa2a8d467"
@@ -2870,10 +3148,10 @@ dependencies = [
  "futures-util",
  "hyper-util",
  "igd-next",
- "iroh-metrics",
+ "iroh-metrics 0.37.0",
  "libc",
  "n0-error",
- "netwatch",
+ "netwatch 0.12.0",
  "num_enum",
  "rand 0.9.2",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1797,7 +1797,11 @@ dependencies = [
  "iroh-quinn",
  "iroh-quinn-proto",
  "iroh-quinn-udp",
+<<<<<<< HEAD
  "iroh-relay 0.94.0",
+=======
+ "iroh-relay",
+>>>>>>> df4c3ab (remove path dep)
  "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "n0-snafu",
  "n0-watcher 0.4.0",
@@ -1945,7 +1949,11 @@ dependencies = [
  "iroh-metrics 0.36.2",
  "iroh-quinn",
  "iroh-tickets",
+<<<<<<< HEAD
  "irpc 0.11.0",
+=======
+ "irpc 0.10.0 (git+https://github.com/n0-computer/irpc?branch=main)",
+>>>>>>> df4c3ab (remove path dep)
  "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "n0-snafu",
  "nested_enum_utils",
@@ -2030,10 +2038,17 @@ dependencies = [
  "futures-util",
  "hex",
  "indexmap",
+<<<<<<< HEAD
  "iroh 0.94.0",
  "iroh-base 0.94.1",
  "iroh-metrics 0.36.2",
  "irpc 0.10.0",
+=======
+ "iroh",
+ "iroh-base",
+ "iroh-metrics",
+ "irpc 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+>>>>>>> df4c3ab (remove path dep)
  "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "n0-snafu",
  "nested_enum_utils",
@@ -2246,9 +2261,16 @@ dependencies = [
  "iroh-metrics 0.37.0",
  "iroh-quinn",
  "iroh-quinn-proto",
+<<<<<<< HEAD
  "lru 0.16.2",
  "n0-error",
  "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+=======
+ "lru 0.16.1",
+ "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "n0-snafu",
+ "nested_enum_utils",
+>>>>>>> df4c3ab (remove path dep)
  "num_enum",
  "pin-project",
  "pkarr",
@@ -2305,7 +2327,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52cf44fdb253f2a3e22e5ecfa8efa466929f8b7cdd4fc0f958f655406e8cdab6"
 dependencies = [
  "futures-util",
+<<<<<<< HEAD
  "irpc-derive 0.8.0",
+=======
+ "irpc-derive 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+>>>>>>> df4c3ab (remove path dep)
  "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "thiserror 2.0.17",
@@ -2322,8 +2348,12 @@ dependencies = [
  "futures-buffered",
  "futures-util",
  "iroh-quinn",
+<<<<<<< HEAD
  "irpc-derive 0.9.0",
  "n0-error",
+=======
+ "irpc-derive 0.8.0 (git+https://github.com/n0-computer/irpc?branch=main)",
+>>>>>>> df4c3ab (remove path dep)
  "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "postcard",
  "rcgen",
@@ -2751,7 +2781,11 @@ dependencies = [
  "js-sys",
  "libc",
  "n0-future 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+<<<<<<< HEAD
  "n0-watcher 0.4.0",
+=======
+ "n0-watcher",
+>>>>>>> df4c3ab (remove path dep)
  "nested_enum_utils",
  "netdev",
  "netlink-packet-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,28 +251,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.37.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
-
-[[package]]
 name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,8 +483,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -530,9 +506,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -581,15 +557,6 @@ name = "clap_lex"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
-
-[[package]]
-name = "cmake"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "cobs"
@@ -831,9 +798,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
@@ -965,12 +932,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1051,7 +1012,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1137,12 +1098,6 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1351,12 +1306,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi",
  "wasip2",
  "wasip3",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1621,7 +1574,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -1876,7 +1829,7 @@ dependencies = [
  "pkcs8",
  "portmapper",
  "rand",
- "reqwest 0.12.28",
+ "reqwest",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
@@ -2078,7 +2031,7 @@ dependencies = [
  "itoa",
  "n0-error",
  "postcard",
- "reqwest 0.12.28",
+ "reqwest",
  "ryu",
  "serde",
  "tokio",
@@ -2110,7 +2063,7 @@ dependencies = [
  "pin-project-lite",
  "rustc-hash",
  "rustls",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -2153,9 +2106,9 @@ checksum = "f981dadd5a072a9e0efcd24bdcc388e570073f7e51b33505ceb1ef4668c80c86"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2192,7 +2145,7 @@ dependencies = [
  "rand",
  "rcgen",
  "reloadable-state",
- "reqwest 0.12.28",
+ "reqwest",
  "rustls",
  "rustls-cert-file-reader",
  "rustls-cert-reloadable-resolver",
@@ -2315,20 +2268,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "f4eacb0641a310445a4c513f2a5e23e19952e269c6a38887254d5f837a305506"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2371,9 +2314,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -2730,7 +2673,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3005,9 +2948,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkarr"
-version = "5.0.3"
+version = "5.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f950360d31be432c0c9467fba5024a94f55128e7f32bc9d32db140369f24c77"
+checksum = "e1d346b545765a0ef58b6a7e160e17ddaa7427f439b7b9a287df6c88c9e04bf2"
 dependencies = [
  "async-compat",
  "base32",
@@ -3018,11 +2961,11 @@ dependencies = [
  "ed25519-dalek",
  "futures-buffered",
  "futures-lite",
- "getrandom 0.4.1",
+ "getrandom 0.3.4",
  "log",
  "lru",
  "ntimestamp",
- "reqwest 0.13.2",
+ "reqwest",
  "self_cell",
  "serde",
  "sha1_smol",
@@ -3259,7 +3202,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3272,7 +3215,6 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
- "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -3297,9 +3239,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3517,41 +3459,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqwest"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
-dependencies = [
- "base64",
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "rustls-platform-verifier",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "resolv-conf"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3603,15 +3510,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3620,7 +3527,6 @@ version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
- "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -3704,7 +3610,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3719,7 +3625,6 @@ version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3809,7 +3714,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4244,15 +4149,15 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4448,7 +4353,7 @@ dependencies = [
  "pem",
  "proc-macro2",
  "rcgen",
- "reqwest 0.12.28",
+ "reqwest",
  "ring",
  "rustls",
  "serde",
@@ -4887,9 +4792,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "05d7d0fce354c88b7982aec4400b3e7fcf723c32737cef571bd165f7613557ee"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4900,9 +4805,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "ee85afca410ac4abba5b584b12e77ea225db6ee5471d0aebaae0861166f9378a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -4914,9 +4819,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "55839b71ba921e4f75b674cb16f843f4b1f3b26ddfcb3454de1cf65cc021ec0f"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4924,9 +4829,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "caf2e969c2d60ff52e7e98b7392ff1588bffdd1ccd4769eba27222fd3d621571"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4937,9 +4842,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "0861f0dcdf46ea819407495634953cdcc8a8c7215ab799a7a7ce366be71c7b30"
 dependencies = [
  "unicode-ident",
 ]
@@ -4993,9 +4898,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "10053fbf9a374174094915bbce141e87a6bf32ecd9a002980db4b638405e8962"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5069,7 +4974,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5594,9 +5499,9 @@ dependencies = [
 
 [[package]]
 name = "wmi"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e49d9da833ef7c4419d8c3a18f0f7a8eca8ccc85f7ab8f359281c24100251211"
+checksum = "003e65f4934cf9449b9ce913ad822cd054a5af669d24f93db101fdb02856bb23"
 dependencies = [
  "chrono",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4651,16 +4651,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-subscriber"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4670,15 +4660,12 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
- "serde",
- "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,3 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(iroh_docsrs)"] }
 
 [build-dependencies]
 cfg_aliases = "0.2.1"
-
-# [patch.crates-io]
-# n0-future = { path = "../n0-future" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,10 @@ futures-buffered = "0.2.4"
 futures-lite = "2.3.0"
 futures-util = { version = "0.3.25" }
 hex = "0.4"
-iroh = { version = "0.94", default-features = false }
-iroh-tickets = { version = "0.1"}
+iroh = { version = "0.95", default-features = false }
+iroh-tickets = { version = "0.2"}
 iroh-blobs = { version = "0.97", default-features = false }
-iroh-gossip = { version = "0.94", features = ["net"], default-features = false }
+iroh-gossip = { version = "0.95", features = ["net"], default-features = false }
 iroh-metrics = { version = "0.36", default-features = false }
 irpc = { version = "0.11", default-features = false }
 n0-future = { version = "0.3", features = ["serde"], git = "https://github.com/n0-computer/n0-future", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ iroh-blobs = { version = "0.97", default-features = false }
 iroh-gossip = { version = "0.95", features = ["net"], default-features = false }
 iroh-metrics = { version = "0.36", default-features = false }
 irpc = { version = "0.11", default-features = false }
-n0-future = { version = "0.3", features = ["serde"], git = "https://github.com/n0-computer/n0-future", branch = "main" }
+n0-future = { version = "0.3.1", features = ["serde"] }
 num_enum = "0.7"
 postcard = { version = "1", default-features = false, features = [
     "alloc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,11 +33,11 @@ futures-util = { version = "0.3.25" }
 hex = "0.4"
 iroh = { version = "0.94", default-features = false }
 iroh-tickets = { version = "0.1"}
-iroh-blobs = { git = "https://github.com/n0-computer/iroh-blobs", branch = "Frando/wasm-nopatch", default-features = false }
+iroh-blobs = { version = "0.97", default-features = false }
 iroh-gossip = { version = "0.94", features = ["net"], default-features = false }
 iroh-metrics = { version = "0.36", default-features = false }
-irpc = { git = "https://github.com/n0-computer/irpc", branch = "main", default-features = false }
-n0-future = { version = "0.3", features = ["serde"], git = "https://github.com/n0-computer/n0-future", branch = "Frando/time-serde" }
+irpc = { version = "0.11", default-features = false }
+n0-future = { version = "0.3", features = ["serde"], git = "https://github.com/n0-computer/n0-future", branch = "main" }
 num_enum = "0.7"
 postcard = { version = "1", default-features = false, features = [
     "alloc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ futures-util = { version = "0.3.25" }
 hex = "0.4"
 iroh = { version = "0.95", default-features = false }
 iroh-tickets = { version = "0.2"}
-iroh-blobs = { version = "0.97", default-features = false }
+iroh-blobs = { version = "0.97", default-features = false, git = "https://github.com/n0-computer/iroh-blobs.git", branch = "b5/fix-std-time" }
 iroh-gossip = { version = "0.95", features = ["net"], default-features = false }
 iroh-metrics = { version = "0.36", default-features = false }
 irpc = { version = "0.11", default-features = false }
@@ -71,8 +71,10 @@ test-strategy = "0.4"
 testdir = "0.7"
 testresult = "0.4.1"
 tokio = { version = "1", features = ["sync", "macros"] }
-tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 tracing-test = "0.2.5"
+
+
+tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tracing-subscriber = { version = "0.3.20", default-features = false, features = ["env-filter", "fmt", "json", "registry"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,12 +31,13 @@ futures-buffered = "0.2.4"
 futures-lite = "2.3.0"
 futures-util = { version = "0.3.25" }
 hex = "0.4"
-iroh = { version = "0.95" }
+iroh = { version = "0.95", default-features = false }
 iroh-tickets = { version = "0.2"}
-iroh-blobs = { version = "0.97" }
-iroh-gossip = { version = "0.95", features = ["net"] }
+iroh-blobs = { version = "0.97", default-features = false }
+iroh-gossip = { version = "0.95", features = ["net"], default-features = false }
 iroh-metrics = { version = "0.37", default-features = false }
 irpc = { version = "0.11.0" }
+
 n0-future = "0.3"
 num_enum = "0.7"
 postcard = { version = "1", default-features = false, features = [
@@ -44,7 +45,7 @@ postcard = { version = "1", default-features = false, features = [
     "use-std",
     "experimental-derive",
 ] }
-quinn = { package = "iroh-quinn", version = "0.14.0" }
+quinn = { package = "iroh-quinn", version = "0.14.0", optional = true }
 rand = "0.9.2"
 redb = { version = "2.6.3" }
 self_cell = "1.0.3"
@@ -75,8 +76,10 @@ tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 tracing-test = "0.2.5"
 
 [features]
-default = ["metrics"]
+default = ["metrics", "rpc", "fs-store"]
 metrics = ["iroh-metrics/metrics", "iroh/metrics"]
+rpc = ["dep:quinn", "irpc/rpc", "iroh-blobs/rpc"]
+fs-store = ["iroh-blobs/fs-store"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ iroh-blobs = { git = "https://github.com/n0-computer/iroh-blobs", branch = "Fran
 iroh-gossip = { version = "0.94", features = ["net"], default-features = false }
 iroh-metrics = { version = "0.36", default-features = false }
 irpc = { git = "https://github.com/n0-computer/irpc", branch = "main", default-features = false }
-n0-future = { version = "0.3", features = ["serde"] }
+n0-future = { version = "0.3", features = ["serde"], git = "https://github.com/n0-computer/n0-future", branch = "Frando/time-serde" }
 num_enum = "0.7"
 postcard = { version = "1", default-features = false, features = [
     "alloc",
@@ -100,5 +100,5 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(iroh_docsrs)"] }
 [build-dependencies]
 cfg_aliases = "0.2.1"
 
-[patch.crates-io]
-n0-future = { path = "../n0-future" }
+# [patch.crates-io]
+# n0-future = { path = "../n0-future" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,9 @@ tokio = { version = "1", features = ["sync", "macros"] }
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 tracing-test = "0.2.5"
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+tracing-subscriber = { version = "0.3.20", default-features = false, features = ["env-filter", "fmt", "json", "registry"] }
+
 [features]
 default = ["metrics", "rpc", "fs-store"]
 metrics = ["iroh-metrics/metrics", "iroh/metrics"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,14 +31,13 @@ futures-buffered = "0.2.4"
 futures-lite = "2.3.0"
 futures-util = { version = "0.3.25" }
 hex = "0.4"
-iroh = { version = "0.95", default-features = false }
-iroh-tickets = { version = "0.2"}
-iroh-blobs = { version = "0.97", default-features = false }
-iroh-gossip = { version = "0.95", features = ["net"], default-features = false }
-iroh-metrics = { version = "0.37", default-features = false }
-irpc = { version = "0.11.0" }
-
-n0-future = "0.3"
+iroh = { version = "0.94", default-features = false }
+iroh-tickets = { version = "0.1"}
+iroh-blobs = { git = "https://github.com/n0-computer/iroh-blobs", branch = "Frando/wasm-nopatch", default-features = false }
+iroh-gossip = { version = "0.94", features = ["net"], default-features = false }
+iroh-metrics = { version = "0.36", default-features = false }
+irpc = { git = "https://github.com/n0-computer/irpc", branch = "main", default-features = false }
+n0-future = { version = "0.3", features = ["serde"] }
 num_enum = "0.7"
 postcard = { version = "1", default-features = false, features = [
     "alloc",
@@ -100,3 +99,6 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(iroh_docsrs)"] }
 
 [build-dependencies]
 cfg_aliases = "0.2.1"
+
+[patch.crates-io]
+n0-future = { path = "../n0-future" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,3 +97,6 @@ missing_debug_implementations = "warn"
 # do.  To enable for a crate set `#![cfg_attr(iroh_docsrs,
 # feature(doc_cfg))]` in the crate.
 unexpected_cfgs = { level = "warn", check-cfg = ["cfg(iroh_docsrs)"] }
+
+[build-dependencies]
+cfg_aliases = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ futures-buffered = "0.2.4"
 futures-lite = "2.3.0"
 futures-util = { version = "0.3.25" }
 hex = "0.4"
-iroh = { version = "0.96", default-features = false }
+iroh = { version = "0.96.1", default-features = false }
 iroh-tickets = { version = "0.2" }
 iroh-blobs = { version = "0.98", default-features = false }
 iroh-gossip = { version = "0.96", features = ["net"], default-features = false }
@@ -61,7 +61,7 @@ tracing = "0.1"
 
 [dev-dependencies]
 data-encoding = "2.6.0"
-iroh = { version = "0.96", features = ["test-utils"] }
+iroh = { version = "0.96.1", features = ["test-utils"] }
 nested_enum_utils = "0.2"
 parking_lot = "0.12.3"
 proptest = "1.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ iroh-blobs = { version = "0.98", default-features = false }
 iroh-gossip = { version = "0.96", features = ["net"], default-features = false }
 iroh-metrics = { version = "0.38", default-features = false }
 irpc = { version = "0.12.0", default-features = false }
+n0-error = "0.1.0"
 n0-future = { version = "0.3.1", features = ["serde"] }
 num_enum = "0.7"
 postcard = { version = "1", default-features = false, features = [
@@ -57,7 +58,6 @@ tokio = { version = "1", features = ["sync", "rt", "time", "io-util"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = { version = "0.7.12", features = ["codec", "io-util", "io", "rt"] }
 tracing = "0.1"
-n0-error = "0.1.0"
 
 [dev-dependencies]
 data-encoding = "2.6.0"
@@ -72,12 +72,7 @@ testdir = "0.7"
 testresult = "0.4.1"
 tokio = { version = "1", features = ["sync", "macros"] }
 tracing-test = "0.2.5"
-
-
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-tracing-subscriber = { version = "0.3.20", default-features = false, features = ["env-filter", "fmt", "json", "registry"] }
 
 [features]
 default = ["metrics", "rpc", "fs-store"]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,9 @@
+use cfg_aliases::cfg_aliases;
+
+fn main() {
+    // Setup cfg aliases
+    cfg_aliases! {
+        // Convenience aliases
+        wasm_browser: { all(target_family = "wasm", target_os = "unknown") },
+    }
+}

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -4,7 +4,6 @@ use std::{
     collections::{hash_map, HashMap},
     num::NonZeroU64,
     sync::Arc,
-    thread::JoinHandle,
     time::Duration,
 };
 
@@ -17,6 +16,9 @@ use n0_future::task::JoinSet;
 use serde::{Deserialize, Serialize};
 use tokio::sync::oneshot;
 use tracing::{debug, error, error_span, trace, warn};
+
+#[cfg(wasm_browser)]
+use tracing::Instrument;
 
 use crate::{
     api::{
@@ -228,6 +230,7 @@ struct OpenReplica {
 pub struct SyncHandle {
     tx: async_channel::Sender<Action>,
     #[cfg(wasm_browser)]
+    #[allow(unused)]
     join_handle: Arc<Option<n0_future::task::JoinHandle<()>>>,
     #[cfg(not(wasm_browser))]
     join_handle: Arc<Option<std::thread::JoinHandle<()>>>,
@@ -275,14 +278,14 @@ impl SyncHandle {
             metrics: metrics.clone(),
         };
 
+        let span = error_span!("sync", %me);
         #[cfg(wasm_browser)]
-        let join_handle = n0_future::task::spawn(actor.run_async());
+        let join_handle = n0_future::task::spawn(actor.run_async().instrument(span));
 
         #[cfg(not(wasm_browser))]
         let join_handle = std::thread::Builder::new()
             .name("sync-actor".to_string())
             .spawn(move || {
-                let span = error_span!("sync", %me);
                 let _enter = span.enter();
 
                 if let Err(err) = actor.run_in_thread() {
@@ -290,6 +293,7 @@ impl SyncHandle {
                 }
             })
             .expect("failed to spawn thread");
+
         let join_handle = Arc::new(Some(join_handle));
         SyncHandle {
             tx: action_tx,
@@ -602,7 +606,15 @@ impl SyncHandle {
 
 impl Drop for SyncHandle {
     fn drop(&mut self) {
+        #[cfg(wasm_browser)]
+        {
+            let tx = self.tx.clone();
+            n0_future::task::spawn(async move {
+                tx.send(Action::Shutdown { reply: None }).await.ok();
+            });
+        }
         // this means we're dropping the last reference
+        #[cfg(not(wasm_browser))]
         if let Some(handle) = Arc::get_mut(&mut self.join_handle) {
             // this call is the reason tx can not be a tokio mpsc channel.
             // we have no control about where drop is called, yet tokio send_blocking panics
@@ -610,7 +622,6 @@ impl Drop for SyncHandle {
             self.tx.send_blocking(Action::Shutdown { reply: None }).ok();
             let handle = handle.take().expect("this can only run once");
 
-            #[cfg(not(wasm_browser))]
             if let Err(err) = handle.join() {
                 warn!(?err, "Failed to join sync actor");
             }
@@ -628,10 +639,7 @@ struct Actor {
 }
 
 impl Actor {
-    async fn run_in_task(self) {
-        self.run_async().await
-    }
-
+    #[cfg(not(wasm_browser))]
     fn run_in_thread(self) -> Result<()> {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_time()
@@ -779,37 +787,46 @@ impl Actor {
                 hash,
                 len,
                 reply,
-            } => send_reply_with(reply, self, move |this| {
-                let author = get_author(&mut this.store, &author)?;
-                let mut replica = this.states.replica(namespace, &mut this.store)?;
-                replica.insert(&key, &author, hash, len)?;
-                this.metrics.new_entries_local.inc();
-                this.metrics.new_entries_local_size.inc_by(len);
-                Ok(())
-            }),
-            ReplicaAction::DeletePrefix { author, key, reply } => {
-                send_reply_with(reply, self, |this| {
+            } => {
+                send_reply_with_async(reply, self, async move |this| {
                     let author = get_author(&mut this.store, &author)?;
                     let mut replica = this.states.replica(namespace, &mut this.store)?;
-                    let res = replica.delete_prefix(&key, &author)?;
+                    replica.insert(&key, &author, hash, len).await?;
+                    this.metrics.new_entries_local.inc();
+                    this.metrics.new_entries_local_size.inc_by(len);
+                    Ok(())
+                })
+                .await
+            }
+            ReplicaAction::DeletePrefix { author, key, reply } => {
+                send_reply_with_async(reply, self, async |this| {
+                    let author = get_author(&mut this.store, &author)?;
+                    let mut replica = this.states.replica(namespace, &mut this.store)?;
+                    let res = replica.delete_prefix(&key, &author).await?;
                     Ok(res)
                 })
+                .await
             }
             ReplicaAction::InsertRemote {
                 entry,
                 from,
                 content_status,
                 reply,
-            } => send_reply_with(reply, self, move |this| {
-                let mut replica = this
-                    .states
-                    .replica_if_syncing(&namespace, &mut this.store)?;
-                let len = entry.content_len();
-                replica.insert_remote_entry(entry, from, content_status)?;
-                this.metrics.new_entries_remote.inc();
-                this.metrics.new_entries_remote_size.inc_by(len);
-                Ok(())
-            }),
+            } => {
+                send_reply_with_async(reply, self, async move |this| {
+                    let mut replica = this
+                        .states
+                        .replica_if_syncing(&namespace, &mut this.store)?;
+                    let len = entry.content_len();
+                    replica
+                        .insert_remote_entry(entry, from, content_status)
+                        .await?;
+                    this.metrics.new_entries_remote.inc();
+                    this.metrics.new_entries_remote_size.inc_by(len);
+                    Ok(())
+                })
+                .await
+            }
 
             ReplicaAction::SyncInitialMessage { reply } => {
                 send_reply_with(reply, self, move |this| {
@@ -1062,6 +1079,14 @@ fn send_reply_with<T>(
     f: impl FnOnce(&mut Actor) -> Result<T>,
 ) -> Result<(), SendReplyError> {
     sender.send(f(this)).map_err(send_reply_error)
+}
+
+async fn send_reply_with_async<T>(
+    sender: oneshot::Sender<Result<T>>,
+    this: &mut Actor,
+    f: impl AsyncFnOnce(&mut Actor) -> Result<T>,
+) -> Result<(), SendReplyError> {
+    sender.send(f(this).await).map_err(send_reply_error)
 }
 
 fn send_reply_error<T>(_err: T) -> SendReplyError {

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -4,7 +4,6 @@ use std::{
     collections::{hash_map, HashMap},
     num::NonZeroU64,
     sync::Arc,
-    time::Duration,
 };
 
 use anyhow::{anyhow, Context, Result};
@@ -12,7 +11,7 @@ use bytes::Bytes;
 use futures_util::FutureExt;
 use iroh_blobs::Hash;
 use irpc::channel::mpsc;
-use n0_future::task::JoinSet;
+use n0_future::{task::JoinSet, time::Duration};
 use serde::{Deserialize, Serialize};
 use tokio::sync::oneshot;
 #[cfg(wasm_browser)]

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -15,10 +15,9 @@ use irpc::channel::mpsc;
 use n0_future::task::JoinSet;
 use serde::{Deserialize, Serialize};
 use tokio::sync::oneshot;
-use tracing::{debug, error, error_span, trace, warn};
-
 #[cfg(wasm_browser)]
 use tracing::Instrument;
+use tracing::{debug, error, error_span, trace, warn};
 
 use crate::{
     api::{

--- a/src/api/actor.rs
+++ b/src/api/actor.rs
@@ -429,7 +429,7 @@ impl RpcActor {
                 return;
             }
         };
-        tokio::task::spawn(async move {
+        n0_future::task::spawn(async move {
             loop {
                 tokio::select! {
                     msg = stream.next() => {

--- a/src/api/protocol.rs
+++ b/src/api/protocol.rs
@@ -304,7 +304,7 @@ pub struct AuthorDeleteResponse;
 
 // Use the macro to generate both the DocsProtocol and DocsMessage enums
 // plus implement Channels for each type
-#[rpc_requests(message = DocsMessage)]
+#[rpc_requests(message = DocsMessage, rpc_feature = "rpc")]
 #[derive(Serialize, Deserialize, Debug)]
 pub enum DocsProtocol {
     #[rpc(tx = oneshot::Sender<RpcResult<OpenResponse>>)]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -372,8 +372,9 @@ impl DefaultAuthorStorage {
             }
             #[cfg(feature = "fs-store")]
             Self::Persistent(ref path) => {
-                use anyhow::Context;
                 use std::str::FromStr;
+
+                use anyhow::Context;
                 if path.exists() {
                     let data = tokio::fs::read_to_string(path).await.with_context(|| {
                         format!(

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2,13 +2,9 @@
 //!
 //! [`crate::Replica`] is also called documents here.
 
-use std::{
-    path::PathBuf,
-    str::FromStr,
-    sync::{Arc, RwLock},
-};
+use std::sync::{Arc, RwLock};
 
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, Result};
 use futures_lite::{Stream, StreamExt};
 use iroh::{Endpoint, EndpointAddr, PublicKey};
 use iroh_blobs::{
@@ -17,9 +13,9 @@ use iroh_blobs::{
     Hash,
 };
 use iroh_gossip::net::Gossip;
+use n0_future::task::AbortOnDropHandle;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, oneshot};
-use tokio_util::task::AbortOnDropHandle;
 use tracing::{debug, error, error_span, Instrument};
 
 use self::live::{LiveActor, ToLiveActor};
@@ -128,7 +124,7 @@ impl Engine {
             live_actor_tx.clone(),
             sync.metrics().clone(),
         );
-        let actor_handle = tokio::task::spawn(
+        let actor_handle = n0_future::task::spawn(
             async move {
                 if let Err(err) = actor.run().await {
                     error!("sync actor failed: {err:?}");
@@ -355,7 +351,8 @@ pub enum DefaultAuthorStorage {
     /// Memory storage.
     Mem,
     /// File based persistent storage.
-    Persistent(PathBuf),
+    #[cfg(feature = "fs-store")]
+    Persistent(std::path::PathBuf),
 }
 
 impl DefaultAuthorStorage {
@@ -373,7 +370,10 @@ impl DefaultAuthorStorage {
                 docs_store.import_author(author).await?;
                 Ok(author_id)
             }
+            #[cfg(feature = "fs-store")]
             Self::Persistent(ref path) => {
+                use anyhow::Context;
+                use std::str::FromStr;
                 if path.exists() {
                     let data = tokio::fs::read_to_string(path).await.with_context(|| {
                         format!(
@@ -407,12 +407,14 @@ impl DefaultAuthorStorage {
     }
 
     /// Save a new default author.
-    pub async fn persist(&self, author_id: AuthorId) -> anyhow::Result<()> {
+    pub async fn persist(&self, #[allow(unused)] author_id: AuthorId) -> anyhow::Result<()> {
         match self {
             Self::Mem => {
                 // persistence is not possible for the mem storage so this is a noop.
             }
+            #[cfg(feature = "fs-store")]
             Self::Persistent(ref path) => {
+                use anyhow::Context;
                 tokio::fs::write(path, author_id.to_string())
                     .await
                     .with_context(|| {

--- a/src/engine/gossip.rs
+++ b/src/engine/gossip.rs
@@ -9,10 +9,8 @@ use iroh_gossip::{
     api::{Event, GossipReceiver, GossipSender, JoinOptions},
     net::Gossip,
 };
-use tokio::{
-    sync::mpsc,
-    task::{AbortHandle, JoinSet},
-};
+use n0_future::task::{AbortHandle, JoinSet};
+use tokio::sync::mpsc;
 use tracing::{debug, instrument, warn};
 
 use super::live::{Op, ToLiveActor};

--- a/src/engine/live.rs
+++ b/src/engine/live.rs
@@ -19,12 +19,10 @@ use iroh_blobs::{
     Hash, HashAndFormat,
 };
 use iroh_gossip::net::Gossip;
+use n0_future::task::JoinSet;
 use n0_future::time::SystemTime;
 use serde::{Deserialize, Serialize};
-use tokio::{
-    sync::{self, mpsc, oneshot},
-    task::JoinSet,
-};
+use tokio::sync::{self, mpsc, oneshot};
 use tracing::{debug, error, info, instrument, trace, warn, Instrument, Span};
 
 // use super::gossip::{GossipActor, ToGossipActor};

--- a/src/engine/live.rs
+++ b/src/engine/live.rs
@@ -4,7 +4,6 @@ use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
 };
-use n0_future::time::SystemTime;
 
 use anyhow::{Context, Result};
 use futures_lite::FutureExt;
@@ -20,6 +19,7 @@ use iroh_blobs::{
     Hash, HashAndFormat,
 };
 use iroh_gossip::net::Gossip;
+use n0_future::time::SystemTime;
 use serde::{Deserialize, Serialize};
 use tokio::{
     sync::{self, mpsc, oneshot},

--- a/src/engine/live.rs
+++ b/src/engine/live.rs
@@ -19,8 +19,7 @@ use iroh_blobs::{
     Hash, HashAndFormat,
 };
 use iroh_gossip::net::Gossip;
-use n0_future::task::JoinSet;
-use n0_future::time::SystemTime;
+use n0_future::{task::JoinSet, time::SystemTime};
 use serde::{Deserialize, Serialize};
 use tokio::sync::{self, mpsc, oneshot};
 use tracing::{debug, error, info, instrument, trace, warn, Instrument, Span};

--- a/src/engine/live.rs
+++ b/src/engine/live.rs
@@ -3,8 +3,8 @@
 use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
-    time::SystemTime,
 };
+use n0_future::time::SystemTime;
 
 use anyhow::{Context, Result};
 use futures_lite::FutureExt;

--- a/src/engine/state.rs
+++ b/src/engine/state.rs
@@ -1,11 +1,8 @@
-use std::{
-    collections::BTreeMap,
-    time::Instant,
-};
-use n0_future::time::SystemTime;
+use std::collections::BTreeMap;
 
 use anyhow::Result;
 use iroh::EndpointId;
+use n0_future::time::{Instant, SystemTime};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
 

--- a/src/engine/state.rs
+++ b/src/engine/state.rs
@@ -1,7 +1,8 @@
 use std::{
     collections::BTreeMap,
-    time::{Instant, SystemTime},
+    time::Instant,
 };
+use n0_future::time::SystemTime;
 
 use anyhow::Result;
 use iroh::EndpointId;

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,11 +1,9 @@
 //! Network implementation of the iroh-docs protocol
 
-use std::{
-    future::Future,
-    time::{Duration, Instant},
-};
+use std::{future::Future, time::Duration};
 
 use iroh::{Endpoint, EndpointAddr, PublicKey};
+use n0_future::time::Instant;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, error_span, trace, Instrument};
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,9 +1,9 @@
 //! Network implementation of the iroh-docs protocol
 
-use std::{future::Future, time::Duration};
+use std::future::Future;
 
 use iroh::{Endpoint, EndpointAddr, PublicKey};
-use n0_future::time::Instant;
+use n0_future::time::{Duration, Instant};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, error_span, trace, Instrument};
 

--- a/src/net/codec.rs
+++ b/src/net/codec.rs
@@ -431,6 +431,7 @@ mod tests {
 
     #[tokio::test]
     #[traced_test]
+    #[cfg(feature = "fs-store")]
     async fn test_sync_many_authors_fs() -> Result<()> {
         let tmpdir = tempfile::tempdir()?;
         let alice_store = store::fs::Store::persistent(tmpdir.path().join("a.db"))?;
@@ -629,6 +630,7 @@ mod tests {
 
     #[tokio::test]
     #[traced_test]
+    #[cfg(feature = "fs-store")]
     async fn test_sync_timestamps_fs() -> Result<()> {
         let tmpdir = tempfile::tempdir()?;
         let alice_store = store::fs::Store::persistent(tmpdir.path().join("a.db"))?;

--- a/src/net/codec.rs
+++ b/src/net/codec.rs
@@ -322,6 +322,7 @@ mod tests {
         let alice_replica_id = alice_replica.id();
         alice_replica
             .hash_and_insert("hello bob", &author, "from alice")
+            .await
             .unwrap();
 
         let mut bob_store = store::Store::memory();
@@ -329,6 +330,7 @@ mod tests {
         let bob_replica_id = bob_replica.id();
         bob_replica
             .hash_and_insert("hello alice", &author, "from bob")
+            .await
             .unwrap();
 
         assert_eq!(
@@ -438,9 +440,9 @@ mod tests {
 
     type Message = (AuthorId, Vec<u8>, Hash);
 
-    fn insert_messages(
+    async fn insert_messages(
         mut rng: impl CryptoRng,
-        replica: &mut crate::sync::Replica,
+        replica: &mut crate::sync::Replica<'_>,
         num_authors: usize,
         msgs_per_author: usize,
         key_value_fn: impl Fn(&AuthorId, usize) -> (String, String),
@@ -453,7 +455,10 @@ mod tests {
         for i in 0..msgs_per_author {
             for author in authors.iter() {
                 let (key, value) = key_value_fn(&author.id(), i);
-                let hash = replica.hash_and_insert(key.clone(), author, value).unwrap();
+                let hash = replica
+                    .hash_and_insert(key.clone(), author, value)
+                    .await
+                    .unwrap();
                 res.push((author.id(), key.as_bytes().to_vec(), hash));
             }
         }
@@ -509,7 +514,8 @@ mod tests {
                             format!("from alice by {author}: {i}"),
                         )
                     },
-                );
+                )
+                .await;
                 all_messages.extend_from_slice(&alice_messages);
 
                 let mut bob_replica = bob_store.new_replica(namespace.clone()).unwrap();
@@ -524,7 +530,8 @@ mod tests {
                             format!("from bob by {author}: {i}"),
                         )
                     },
-                );
+                )
+                .await;
                 all_messages.extend_from_slice(&bob_messages);
 
                 all_messages.sort();
@@ -646,10 +653,12 @@ mod tests {
         // Insert into alice
         let hash_alice = alice_replica
             .hash_and_insert(&key, &author, &value_alice)
+            .await
             .unwrap();
         // Insert into bob
         let hash_bob = bob_replica
             .hash_and_insert(&key, &author, &value_bob)
+            .await
             .unwrap();
 
         assert_eq!(

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -28,6 +28,7 @@ impl Docs {
 
     /// Create a new [`Builder`] for the docs protocol, using a persistent replica and author storage
     /// in the given directory.
+    #[cfg(feature = "fs-store")]
     pub fn persistent(path: PathBuf) -> Builder {
         Builder {
             path: Some(path),

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,6 +1,6 @@
 //! [`ProtocolHandler`] implementation for the docs [`Engine`].
 
-use std::{path::PathBuf, sync::Arc};
+use std::sync::Arc;
 
 use anyhow::Result;
 use iroh::{endpoint::Connection, protocol::ProtocolHandler, Endpoint};
@@ -12,6 +12,14 @@ use crate::{
     engine::{DefaultAuthorStorage, Engine, ProtectCallbackHandler},
     store::Store,
 };
+
+#[derive(Default, Debug)]
+enum Storage {
+    #[default]
+    Memory,
+    #[cfg(feature = "fs-store")]
+    Persistent(std::path::PathBuf),
+}
 
 /// Docs protocol.
 #[derive(Debug, Clone)]
@@ -29,9 +37,9 @@ impl Docs {
     /// Create a new [`Builder`] for the docs protocol, using a persistent replica and author storage
     /// in the given directory.
     #[cfg(feature = "fs-store")]
-    pub fn persistent(path: PathBuf) -> Builder {
+    pub fn persistent(path: std::path::PathBuf) -> Builder {
         Builder {
-            path: Some(path),
+            storage: Storage::Persistent(path),
             protect_cb: None,
         }
     }
@@ -76,7 +84,7 @@ impl ProtocolHandler for Docs {
 /// Builder for the docs protocol.
 #[derive(Debug, Default)]
 pub struct Builder {
-    path: Option<PathBuf>,
+    storage: Storage,
     protect_cb: Option<ProtectCallbackHandler>,
 }
 
@@ -96,13 +104,17 @@ impl Builder {
         blobs: BlobsStore,
         gossip: Gossip,
     ) -> anyhow::Result<Docs> {
-        let replica_store = match self.path {
-            Some(ref path) => Store::persistent(path.join("docs.redb"))?,
-            None => Store::memory(),
+        let replica_store = match &self.storage {
+            Storage::Memory => Store::memory(),
+            #[cfg(feature = "fs-store")]
+            Storage::Persistent(path) => Store::persistent(path.join("docs.redb"))?,
         };
-        let author_store = match self.path {
-            Some(ref path) => DefaultAuthorStorage::Persistent(path.join("default-author")),
-            None => DefaultAuthorStorage::Mem,
+        let author_store = match &self.storage {
+            Storage::Memory => DefaultAuthorStorage::Mem,
+            #[cfg(feature = "fs-store")]
+            Storage::Persistent(path) => {
+                DefaultAuthorStorage::Persistent(path.join("default-author"))
+            }
         };
         let downloader = blobs.downloader(&endpoint);
         let engine = Engine::spawn(

--- a/src/ranger.rs
+++ b/src/ranger.rs
@@ -1,7 +1,7 @@
 //! Implementation of Set Reconcilliation based on
 //! "Range-Based Set Reconciliation" by Aljoscha Meyer.
 
-use std::{fmt::Debug, pin::Pin};
+use std::fmt::Debug;
 
 use n0_future::StreamExt;
 use serde::{Deserialize, Serialize};
@@ -330,11 +330,8 @@ pub trait Store<E: RangeEntry>: Sized {
     ) -> Result<Option<Message<E>>, Self::Error>
     where
         F: Fn(&Self, &E, ContentStatus) -> bool,
-        F2: FnMut(&Self, E, ContentStatus),
-        F3: for<'a> Fn(
-            &'a E,
-        )
-            -> Pin<Box<dyn std::future::Future<Output = ContentStatus> + Send + 'a>>,
+        F2: AsyncFnMut(&Self, E, ContentStatus),
+        F3: for<'a> AsyncFn(&'a E) -> ContentStatus,
     {
         let mut out = Vec::new();
 
@@ -397,7 +394,7 @@ pub trait Store<E: RangeEntry>: Sized {
                     // TODO: Get rid of the clone?
                     let outcome = self.put(entry.clone())?;
                     if let InsertOutcome::Inserted { .. } = outcome {
-                        on_insert_cb(self, entry, content_status);
+                        on_insert_cb(self, entry, content_status).await;
                     }
                 }
             }
@@ -1419,8 +1416,8 @@ mod tests {
                     &Default::default(),
                     msg,
                     &bob_validate_cb,
-                    |_, _, _| (),
-                    |_| Box::pin(async move { ContentStatus::Complete }),
+                    async |_, _, _| (),
+                    async |_| ContentStatus::Complete,
                 )
                 .await
                 .unwrap()
@@ -1431,8 +1428,8 @@ mod tests {
                         &Default::default(),
                         msg,
                         &alice_validate_cb,
-                        |_, _, _| (),
-                        |_| Box::pin(async move { ContentStatus::Complete }),
+                        async |_, _, _| (),
+                        async |_| ContentStatus::Complete,
                     )
                     .await
                     .unwrap();

--- a/src/ranger.rs
+++ b/src/ranger.rs
@@ -288,6 +288,7 @@ pub trait Store<E: RangeEntry>: Sized {
     ///
     /// This will remove just the entry with the given key, but will not perform prefix deletion.
     #[cfg(test)]
+    #[allow(unused)]
     fn entry_remove(&mut self, key: &E::Key) -> Result<Option<E>, Self::Error>;
 
     /// Remove all entries whose key start with a prefix and for which the `predicate` callback

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -11,6 +11,7 @@ use std::{
 use anyhow::{anyhow, Result};
 use ed25519_dalek::{SignatureError, VerifyingKey};
 use iroh_blobs::Hash;
+use n0_future::time::SystemTime;
 use rand::CryptoRng;
 use redb::{Database, ReadableMultimapTable, ReadableTable};
 use tracing::warn;
@@ -487,7 +488,7 @@ impl Store {
         let peer = &peer;
         let namespace = namespace.as_bytes();
         // calculate nanos since UNIX_EPOCH for a time measurement
-        let nanos = std::time::UNIX_EPOCH
+        let nanos = SystemTime::UNIX_EPOCH
             .elapsed()
             .map(|duration| duration.as_nanos() as u64)?;
         self.modify(|tables| {

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -990,6 +990,7 @@ mod tests {
     use crate::ranger::Store as _;
 
     #[tokio::test]
+    #[cfg(feature = "fs-store")]
     async fn test_ranges() -> Result<()> {
         let dbfile = tempfile::NamedTempFile::new()?;
         let mut store = Store::persistent(dbfile.path())?;
@@ -1017,6 +1018,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "fs-store")]
     fn test_basics() -> Result<()> {
         let dbfile = tempfile::NamedTempFile::new()?;
         let mut store = Store::persistent(dbfile.path())?;
@@ -1108,6 +1110,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "fs-store")]
     async fn test_migration_001_populate_latest_table() -> Result<()> {
         let dbfile = tempfile::NamedTempFile::new()?;
         let namespace = NamespaceSecret::new(&mut rand::rng());
@@ -1151,6 +1154,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "fs-store")]
     fn test_migration_004_populate_by_key_index() -> Result<()> {
         use redb::ReadableTableMetadata;
         let dbfile = tempfile::NamedTempFile::new()?;

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -6,15 +6,14 @@ use std::{
     iter::{Chain, Flatten},
     num::NonZeroU64,
     ops::Bound,
-    path::Path,
 };
 
 use anyhow::{anyhow, Result};
 use ed25519_dalek::{SignatureError, VerifyingKey};
 use iroh_blobs::Hash;
 use rand::CryptoRng;
-use redb::{Database, DatabaseError, ReadableMultimapTable, ReadableTable};
-use tracing::{info, warn};
+use redb::{Database, ReadableMultimapTable, ReadableTable};
+use tracing::warn;
 
 use super::{
     pubkeys::MemPublicKeyStore, DownloadPolicy, ImportNamespaceOutcome, OpenError, PublicKeyStore,
@@ -98,16 +97,17 @@ impl Store {
     /// Create or open a store from a `path` to a database file.
     ///
     /// The file will be created if it does not exist, otherwise it will be opened.
-    pub fn persistent(path: impl AsRef<Path>) -> Result<Self> {
+    #[cfg(feature = "fs-store")]
+    pub fn persistent(path: impl AsRef<std::path::Path>) -> Result<Self> {
         let mut db = match Database::create(&path) {
             Ok(db) => db,
-            Err(DatabaseError::UpgradeRequired(1)) => return Err(
+            Err(redb::DatabaseError::UpgradeRequired(1)) => return Err(
                 anyhow!("Opening the database failed: Upgrading from old format is no longer supported. Use iroh-docs 0.92 to perform the upgrade, then upgrade to the latest release again.")
             ),
             Err(err) => return Err(err.into()),
         };
         match db.upgrade() {
-            Ok(true) => info!("Database was upgraded to redb v3 compatible format"),
+            Ok(true) => tracing::info!("Database was upgraded to redb v3 compatible format"),
             Ok(false) => {}
             Err(err) => warn!("Database upgrade to redb v3 compatible format failed: {err:#}"),
         }
@@ -989,8 +989,8 @@ mod tests {
     use super::{tables::LATEST_PER_AUTHOR_TABLE, *};
     use crate::ranger::Store as _;
 
-    #[test]
-    fn test_ranges() -> Result<()> {
+    #[tokio::test]
+    async fn test_ranges() -> Result<()> {
         let dbfile = tempfile::NamedTempFile::new()?;
         let mut store = Store::persistent(dbfile.path())?;
 
@@ -1001,8 +1001,8 @@ mod tests {
         // test author prefix relation for all-255 keys
         let key1 = vec![255, 255];
         let key2 = vec![255, 255, 255];
-        replica.hash_and_insert(&key1, &author, b"v1")?;
-        replica.hash_and_insert(&key2, &author, b"v2")?;
+        replica.hash_and_insert(&key1, &author, b"v1").await?;
+        replica.hash_and_insert(&key2, &author, b"v2").await?;
         let res = store
             .get_many(namespace.id(), Query::author(author.id()).key_prefix([255]))?
             .collect::<Result<Vec<_>>>()?;
@@ -1094,7 +1094,7 @@ mod tests {
     }
 
     fn copy_and_modify(
-        source: &Path,
+        source: &std::path::Path,
         modify: impl Fn(&redb::WriteTransaction) -> Result<()>,
     ) -> Result<tempfile::NamedTempFile> {
         let dbfile = tempfile::NamedTempFile::new()?;
@@ -1107,8 +1107,8 @@ mod tests {
         Ok(dbfile)
     }
 
-    #[test]
-    fn test_migration_001_populate_latest_table() -> Result<()> {
+    #[tokio::test]
+    async fn test_migration_001_populate_latest_table() -> Result<()> {
         let dbfile = tempfile::NamedTempFile::new()?;
         let namespace = NamespaceSecret::new(&mut rand::rng());
 
@@ -1118,9 +1118,9 @@ mod tests {
             let author1 = store.new_author(&mut rand::rng())?;
             let author2 = store.new_author(&mut rand::rng())?;
             let mut replica = store.new_replica(namespace.clone())?;
-            replica.hash_and_insert(b"k1", &author1, b"v1")?;
-            replica.hash_and_insert(b"k2", &author2, b"v1")?;
-            replica.hash_and_insert(b"k3", &author1, b"v1")?;
+            replica.hash_and_insert(b"k1", &author1, b"v1").await?;
+            replica.hash_and_insert(b"k2", &author2, b"v1").await?;
+            replica.hash_and_insert(b"k3", &author1, b"v1").await?;
 
             let expected = store
                 .get_latest_for_each_author(namespace.id())?

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -984,13 +984,12 @@ fn into_entry(key: RecordsId, value: RecordsValue) -> SignedEntry {
     SignedEntry::new(entry_signature, entry)
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "fs-store"))]
 mod tests {
-    use super::{tables::LATEST_PER_AUTHOR_TABLE, *};
+    use super::*;
     use crate::ranger::Store as _;
 
     #[tokio::test]
-    #[cfg(feature = "fs-store")]
     async fn test_ranges() -> Result<()> {
         let dbfile = tempfile::NamedTempFile::new()?;
         let mut store = Store::persistent(dbfile.path())?;
@@ -1018,7 +1017,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "fs-store")]
     fn test_basics() -> Result<()> {
         let dbfile = tempfile::NamedTempFile::new()?;
         let mut store = Store::persistent(dbfile.path())?;
@@ -1112,6 +1110,7 @@ mod tests {
     #[tokio::test]
     #[cfg(feature = "fs-store")]
     async fn test_migration_001_populate_latest_table() -> Result<()> {
+        use super::tables::LATEST_PER_AUTHOR_TABLE;
         let dbfile = tempfile::NamedTempFile::new()?;
         let namespace = NamespaceSecret::new(&mut rand::rng());
 

--- a/src/store/fs/tables.rs
+++ b/src/store/fs/tables.rs
@@ -61,7 +61,7 @@ pub type RecordsByKeyIdOwned = ([u8; 32], Bytes, [u8; 32]);
 /// Value: `(u64, [u8; 32])` # ([`Nanos`], &[`PeerIdBytes`]) representing the last time a peer was used.
 pub const NAMESPACE_PEERS_TABLE: MultimapTableDefinition<&[u8; 32], (Nanos, &PeerIdBytes)> =
     MultimapTableDefinition::new("sync-peers-1");
-/// Number of seconds elapsed since [`std::time::SystemTime::UNIX_EPOCH`]. Used to register the
+/// Number of seconds elapsed since [`n0_future::time::SystemTime::UNIX_EPOCH`]. Used to register the
 /// last time a peer was useful in a document.
 // NOTE: resolution is nanoseconds, stored as a u64 since this covers ~500years from unix epoch,
 // which should be more than enough

--- a/src/store/fs/tables.rs
+++ b/src/store/fs/tables.rs
@@ -1,9 +1,8 @@
 #![allow(missing_docs)]
 // Table Definitions
 
-use std::time::Instant;
-
 use bytes::Bytes;
+use n0_future::time::Instant;
 use redb::{
     MultimapTable, MultimapTableDefinition, ReadOnlyMultimapTable, ReadOnlyTable, ReadTransaction,
     Table, TableDefinition, WriteTransaction,

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -11,13 +11,15 @@ use std::{
     fmt::Debug,
     ops::{Deref, DerefMut},
     sync::Arc,
-    time::Duration,
 };
 
 use bytes::{Bytes, BytesMut};
 use ed25519_dalek::{Signature, SignatureError};
 use iroh_blobs::Hash;
-use n0_future::{time::SystemTime, IterExt};
+use n0_future::{
+    time::{Duration, SystemTime},
+    IterExt,
+};
 use serde::{Deserialize, Serialize};
 
 pub use crate::heads::AuthorHeads;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -6,12 +6,13 @@
 //
 // This is going to change!
 
+use n0_future::{time::SystemTime, IterExt};
 use std::{
     cmp::Ordering,
     fmt::Debug,
     ops::{Deref, DerefMut},
     sync::Arc,
-    time::{Duration, SystemTime},
+    time::Duration,
 };
 
 use bytes::{Bytes, BytesMut};
@@ -129,16 +130,22 @@ impl Subscribers {
     pub fn unsubscribe(&mut self, sender: &async_channel::Sender<Event>) {
         self.0.retain(|s| !same_channel(s, sender));
     }
-    pub fn send(&mut self, event: Event) {
-        self.0
-            .retain(|sender| sender.send_blocking(event.clone()).is_ok())
+    pub async fn send(&mut self, event: Event) {
+        self.0 = std::mem::take(&mut self.0)
+            .into_iter()
+            .map(async |tx| tx.send(event.clone()).await.ok().map(|_| tx))
+            .join_all()
+            .await
+            .into_iter()
+            .flatten()
+            .collect();
     }
     pub fn len(&self) -> usize {
         self.0.len()
     }
-    pub fn send_with(&mut self, f: impl FnOnce() -> Event) {
+    pub async fn send_with(&mut self, f: impl FnOnce() -> Event) {
         if !self.0.is_empty() {
-            self.send(f())
+            self.send(f()).await
         }
     }
 }
@@ -361,7 +368,7 @@ where
     ///
     /// Returns the number of entries removed as a consequence of this insertion,
     /// or an error either if the entry failed to validate or if a store operation failed.
-    pub fn insert(
+    pub async fn insert(
         &mut self,
         key: impl AsRef<[u8]>,
         author: &Author,
@@ -377,7 +384,7 @@ where
         let entry = Entry::new(id, record);
         let secret = self.secret_key()?;
         let signed_entry = entry.sign(secret, author);
-        self.insert_entry(signed_entry, InsertOrigin::Local)
+        self.insert_entry(signed_entry, InsertOrigin::Local).await
     }
 
     /// Delete entries that match the given `author` and key `prefix`.
@@ -386,7 +393,7 @@ where
     /// entries whose key starts with or is equal to the given `prefix`.
     ///
     /// Returns the number of entries deleted.
-    pub fn delete_prefix(
+    pub async fn delete_prefix(
         &mut self,
         prefix: impl AsRef<[u8]>,
         author: &Author,
@@ -395,7 +402,7 @@ where
         let id = RecordIdentifier::new(self.id(), author.id(), prefix);
         let entry = Entry::new_empty(id);
         let signed_entry = entry.sign(self.secret_key()?, author);
-        self.insert_entry(signed_entry, InsertOrigin::Local)
+        self.insert_entry(signed_entry, InsertOrigin::Local).await
     }
 
     /// Insert an entry into this replica which was received from a remote peer.
@@ -405,7 +412,7 @@ where
     ///
     /// Returns the number of entries removed as a consequence of this insertion,
     /// or an error if the entry failed to validate or if a store operation failed.
-    pub fn insert_remote_entry(
+    pub async fn insert_remote_entry(
         &mut self,
         entry: SignedEntry,
         received_from: PeerIdBytes,
@@ -417,13 +424,13 @@ where
             from: received_from,
             remote_content_status: content_status,
         };
-        self.insert_entry(entry, origin)
+        self.insert_entry(entry, origin).await
     }
 
     /// Insert a signed entry into the database.
     ///
     /// Returns the number of entries removed as a consequence of this insertion.
-    fn insert_entry(
+    async fn insert_entry(
         &mut self,
         entry: SignedEntry,
         origin: InsertOrigin,
@@ -462,7 +469,7 @@ where
             }
         };
 
-        self.info.subscribers.send(insert_event);
+        self.info.subscribers.send(insert_event).await;
 
         Ok(removed_count)
     }
@@ -471,7 +478,7 @@ where
     ///
     /// This does not store the content, just the record of it.
     /// Returns the calculated hash.
-    pub fn hash_and_insert(
+    pub async fn hash_and_insert(
         &mut self,
         key: impl AsRef<[u8]>,
         author: &Author,
@@ -480,7 +487,7 @@ where
         self.info.ensure_open()?;
         let len = data.as_ref().len() as u64;
         let hash = Hash::new(data);
-        self.insert(key, author, hash, len)?;
+        self.insert(key, author, hash, len).await?;
         Ok(hash)
     }
 
@@ -537,29 +544,29 @@ where
                     validate_entry(now, store, my_namespace, entry, &origin).is_ok()
                 },
                 // on_insert callback: is called when an entry was actually inserted in the store
-                |_store, entry, content_status| {
+                async |_store, entry, content_status| {
                     // We use `send_with` to only clone the entry if we have active subscriptions.
-                    self.info.subscribers.send_with(|| {
-                        let should_download = download_policy.matches(entry.entry());
-                        Event::RemoteInsert {
-                            from: from_peer,
-                            namespace: my_namespace,
-                            entry: entry.clone(),
-                            should_download,
-                            remote_content_status: content_status,
-                        }
-                    })
+                    self.info
+                        .subscribers
+                        .send_with(|| {
+                            let should_download = download_policy.matches(entry.entry());
+                            Event::RemoteInsert {
+                                from: from_peer,
+                                namespace: my_namespace,
+                                entry: entry.clone(),
+                                should_download,
+                                remote_content_status: content_status,
+                            }
+                        })
+                        .await
                 },
                 // content_status callback: get content status for outgoing entries
-                move |entry| {
-                    let cb = cb.clone();
-                    Box::pin(async move {
-                        if let Some(cb) = cb.as_ref() {
-                            cb(entry.content_hash()).await
-                        } else {
-                            ContentStatus::Missing
-                        }
-                    })
+                async move |entry| {
+                    if let Some(cb) = cb.as_ref() {
+                        cb(entry.content_hash()).await
+                    } else {
+                        ContentStatus::Missing
+                    }
                 },
             )
             .await?;
@@ -1205,23 +1212,23 @@ mod tests {
         store::{OpenError, Query, SortBy, SortDirection, Store},
     };
 
-    #[test]
-    fn test_basics_memory() -> Result<()> {
+    #[tokio::test]
+    async fn test_basics_memory() -> Result<()> {
         let store = store::Store::memory();
-        test_basics(store)?;
+        test_basics(store).await?;
 
         Ok(())
     }
 
-    #[test]
-    fn test_basics_fs() -> Result<()> {
+    #[tokio::test]
+    async fn test_basics_fs() -> Result<()> {
         let dbfile = tempfile::NamedTempFile::new()?;
         let store = store::fs::Store::persistent(dbfile.path())?;
-        test_basics(store)?;
+        test_basics(store).await?;
         Ok(())
     }
 
-    fn test_basics(mut store: Store) -> Result<()> {
+    async fn test_basics(mut store: Store) -> Result<()> {
         let mut rng = rand::rng();
         let alice = Author::new(&mut rng);
         let bob = Author::new(&mut rng);
@@ -1235,11 +1242,9 @@ mod tests {
 
         let mut my_replica = store.new_replica(myspace.clone())?;
         for i in 0..10 {
-            my_replica.hash_and_insert(
-                format!("/{i}"),
-                &alice,
-                format!("{i}: hello from alice"),
-            )?;
+            my_replica
+                .hash_and_insert(format!("/{i}"), &alice, format!("{i}: hello from alice"))
+                .await?;
         }
 
         for i in 0..10 {
@@ -1253,13 +1258,17 @@ mod tests {
 
         // Test multiple records for the same key
         let mut my_replica = store.new_replica(myspace.clone())?;
-        my_replica.hash_and_insert("/cool/path", &alice, "round 1")?;
+        my_replica
+            .hash_and_insert("/cool/path", &alice, "round 1")
+            .await?;
         let _entry = store
             .get_exact(myspace.id(), alice.id(), "/cool/path", false)?
             .unwrap();
         // Second
         let mut my_replica = store.new_replica(myspace.clone())?;
-        my_replica.hash_and_insert("/cool/path", &alice, "round 2")?;
+        my_replica
+            .hash_and_insert("/cool/path", &alice, "round 2")
+            .await?;
         let _entry = store
             .get_exact(myspace.id(), alice.id(), "/cool/path", false)?
             .unwrap();
@@ -1290,7 +1299,9 @@ mod tests {
 
         // insert record from different author
         let mut my_replica = store.new_replica(myspace.clone())?;
-        let _entry = my_replica.hash_and_insert("/cool/path", &bob, "bob round 1")?;
+        let _entry = my_replica
+            .hash_and_insert("/cool/path", &bob, "bob round 1")
+            .await?;
 
         // Get All by author
         let entries: Vec<_> = store
@@ -1392,20 +1403,20 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn test_content_hashes_iterator_memory() -> Result<()> {
+    #[tokio::test]
+    async fn test_content_hashes_iterator_memory() -> Result<()> {
         let store = store::Store::memory();
-        test_content_hashes_iterator(store)
+        test_content_hashes_iterator(store).await
     }
 
-    #[test]
-    fn test_content_hashes_iterator_fs() -> Result<()> {
+    #[tokio::test]
+    async fn test_content_hashes_iterator_fs() -> Result<()> {
         let dbfile = tempfile::NamedTempFile::new()?;
         let store = store::fs::Store::persistent(dbfile.path())?;
-        test_content_hashes_iterator(store)
+        test_content_hashes_iterator(store).await
     }
 
-    fn test_content_hashes_iterator(mut store: Store) -> Result<()> {
+    async fn test_content_hashes_iterator(mut store: Store) -> Result<()> {
         let mut rng = rand::rng();
         let mut expected = HashSet::new();
         let n_replicas = 3;
@@ -1417,7 +1428,7 @@ mod tests {
             for j in 0..n_entries {
                 let key = format!("{j}");
                 let data = format!("{i}:{j}");
-                let hash = replica.hash_and_insert(key, &author, data)?;
+                let hash = replica.hash_and_insert(key, &author, data).await?;
                 expected.insert(hash);
             }
         }
@@ -1517,23 +1528,23 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_timestamps_memory() -> Result<()> {
+    #[tokio::test]
+    async fn test_timestamps_memory() -> Result<()> {
         let store = store::Store::memory();
-        test_timestamps(store)?;
+        test_timestamps(store).await?;
 
         Ok(())
     }
 
-    #[test]
-    fn test_timestamps_fs() -> Result<()> {
+    #[tokio::test]
+    async fn test_timestamps_fs() -> Result<()> {
         let dbfile = tempfile::NamedTempFile::new()?;
         let store = store::fs::Store::persistent(dbfile.path())?;
-        test_timestamps(store)?;
+        test_timestamps(store).await?;
         Ok(())
     }
 
-    fn test_timestamps(mut store: Store) -> Result<()> {
+    async fn test_timestamps(mut store: Store) -> Result<()> {
         let mut rng = rand_chacha::ChaCha12Rng::seed_from_u64(1);
         let namespace = NamespaceSecret::new(&mut rng);
         let _replica = store.new_replica(namespace.clone())?;
@@ -1552,6 +1563,7 @@ mod tests {
 
         replica
             .insert_entry(entry.clone(), InsertOrigin::Local)
+            .await
             .unwrap();
         store.close_replica(namespace.id());
         let res = store
@@ -1567,7 +1579,7 @@ mod tests {
         };
 
         let mut replica = store.open_replica(&namespace.id())?;
-        let res = replica.insert_entry(entry2, InsertOrigin::Local);
+        let res = replica.insert_entry(entry2, InsertOrigin::Local).await;
         store.close_replica(namespace.id());
         assert!(matches!(res, Err(InsertError::NewerEntryExists)));
         let res = store
@@ -1607,12 +1619,12 @@ mod tests {
         let myspace = NamespaceSecret::new(&mut rng);
         let mut alice = alice_store.new_replica(myspace.clone())?;
         for el in &alice_set {
-            alice.hash_and_insert(el, &author, el.as_bytes())?;
+            alice.hash_and_insert(el, &author, el.as_bytes()).await?;
         }
 
         let mut bob = bob_store.new_replica(myspace.clone())?;
         for el in &bob_set {
-            bob.hash_and_insert(el, &author, el.as_bytes())?;
+            bob.hash_and_insert(el, &author, el.as_bytes()).await?;
         }
 
         let (alice_out, bob_out) = sync(&mut alice, &mut bob).await?;
@@ -1664,9 +1676,9 @@ mod tests {
         let key = b"key";
         let alice_value = b"alice";
         let bob_value = b"bob";
-        let _alice_hash = alice.hash_and_insert(key, &author, alice_value)?;
+        let _alice_hash = alice.hash_and_insert(key, &author, alice_value).await?;
         // system time increased - sync should overwrite
-        let bob_hash = bob.hash_and_insert(key, &author, bob_value)?;
+        let bob_hash = bob.hash_and_insert(key, &author, bob_value).await?;
         sync(&mut alice, &mut bob).await?;
         assert_eq!(
             get_content_hash(&mut alice_store, namespace.id(), author.id(), key)?,
@@ -1682,8 +1694,8 @@ mod tests {
 
         let alice_value_2 = b"alice2";
         // system time increased - sync should overwrite
-        let _bob_hash_2 = bob.hash_and_insert(key, &author, bob_value)?;
-        let alice_hash_2 = alice.hash_and_insert(key, &author, alice_value_2)?;
+        let _bob_hash_2 = bob.hash_and_insert(key, &author, bob_value).await?;
+        let alice_hash_2 = alice.hash_and_insert(key, &author, alice_value_2).await?;
         sync(&mut alice, &mut bob).await?;
         assert_eq!(
             get_content_hash(&mut alice_store, namespace.id(), author.id(), key)?,
@@ -1698,8 +1710,8 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn test_future_timestamp() -> Result<()> {
+    #[tokio::test]
+    async fn test_future_timestamp() -> Result<()> {
         let mut rng = rand::rng();
         let mut store = store::Store::memory();
         let author = Author::new(&mut rng);
@@ -1710,7 +1722,9 @@ mod tests {
         let t = system_time_now();
         let record = Record::from_data(b"1", t);
         let entry0 = SignedEntry::from_parts(&namespace, &author, key, record);
-        replica.insert_entry(entry0.clone(), InsertOrigin::Local)?;
+        replica
+            .insert_entry(entry0.clone(), InsertOrigin::Local)
+            .await?;
 
         assert_eq!(
             get_entry(&mut store, namespace.id(), author.id(), key)?,
@@ -1721,7 +1735,9 @@ mod tests {
         let t = system_time_now() + MAX_TIMESTAMP_FUTURE_SHIFT - 10000;
         let record = Record::from_data(b"2", t);
         let entry1 = SignedEntry::from_parts(&namespace, &author, key, record);
-        replica.insert_entry(entry1.clone(), InsertOrigin::Local)?;
+        replica
+            .insert_entry(entry1.clone(), InsertOrigin::Local)
+            .await?;
         assert_eq!(
             get_entry(&mut store, namespace.id(), author.id(), key)?,
             entry1
@@ -1731,7 +1747,9 @@ mod tests {
         let t = system_time_now() + MAX_TIMESTAMP_FUTURE_SHIFT;
         let record = Record::from_data(b"2", t);
         let entry2 = SignedEntry::from_parts(&namespace, &author, key, record);
-        replica.insert_entry(entry2.clone(), InsertOrigin::Local)?;
+        replica
+            .insert_entry(entry2.clone(), InsertOrigin::Local)
+            .await?;
         assert_eq!(
             get_entry(&mut store, namespace.id(), author.id(), key)?,
             entry2
@@ -1741,7 +1759,7 @@ mod tests {
         let t = system_time_now() + MAX_TIMESTAMP_FUTURE_SHIFT + 10000;
         let record = Record::from_data(b"2", t);
         let entry3 = SignedEntry::from_parts(&namespace, &author, key, record);
-        let res = replica.insert_entry(entry3, InsertOrigin::Local);
+        let res = replica.insert_entry(entry3, InsertOrigin::Local).await;
         assert!(matches!(
             res,
             Err(InsertError::Validation(
@@ -1756,42 +1774,42 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn test_insert_empty() -> Result<()> {
+    #[tokio::test]
+    async fn test_insert_empty() -> Result<()> {
         let mut store = store::Store::memory();
         let mut rng = rand::rng();
         let alice = Author::new(&mut rng);
         let myspace = NamespaceSecret::new(&mut rng);
         let mut replica = store.new_replica(myspace.clone())?;
         let hash = Hash::new(b"");
-        let res = replica.insert(b"foo", &alice, hash, 0);
+        let res = replica.insert(b"foo", &alice, hash, 0).await;
         assert!(matches!(res, Err(InsertError::EntryIsEmpty)));
         store.flush()?;
         Ok(())
     }
 
-    #[test]
-    fn test_prefix_delete_memory() -> Result<()> {
+    #[tokio::test]
+    async fn test_prefix_delete_memory() -> Result<()> {
         let store = store::Store::memory();
-        test_prefix_delete(store)?;
+        test_prefix_delete(store).await?;
         Ok(())
     }
 
-    #[test]
-    fn test_prefix_delete_fs() -> Result<()> {
+    #[tokio::test]
+    async fn test_prefix_delete_fs() -> Result<()> {
         let dbfile = tempfile::NamedTempFile::new()?;
         let store = store::fs::Store::persistent(dbfile.path())?;
-        test_prefix_delete(store)?;
+        test_prefix_delete(store).await?;
         Ok(())
     }
 
-    fn test_prefix_delete(mut store: Store) -> Result<()> {
+    async fn test_prefix_delete(mut store: Store) -> Result<()> {
         let mut rng = rand::rng();
         let alice = Author::new(&mut rng);
         let myspace = NamespaceSecret::new(&mut rng);
         let mut replica = store.new_replica(myspace.clone())?;
-        let hash1 = replica.hash_and_insert(b"foobar", &alice, b"hello")?;
-        let hash2 = replica.hash_and_insert(b"fooboo", &alice, b"world")?;
+        let hash1 = replica.hash_and_insert(b"foobar", &alice, b"hello").await?;
+        let hash2 = replica.hash_and_insert(b"fooboo", &alice, b"world").await?;
 
         // sanity checks
         assert_eq!(
@@ -1805,7 +1823,7 @@ mod tests {
 
         // delete
         let mut replica = store.new_replica(myspace.clone())?;
-        let deleted = replica.delete_prefix(b"foo", &alice)?;
+        let deleted = replica.delete_prefix(b"foo", &alice).await?;
         assert_eq!(deleted, 2);
         assert_eq!(
             store.get_exact(myspace.id(), alice.id(), b"foobar", false)?,
@@ -1849,12 +1867,12 @@ mod tests {
         let myspace = NamespaceSecret::new(&mut rng);
         let mut alice = alice_store.new_replica(myspace.clone())?;
         for el in &alice_set {
-            alice.hash_and_insert(el, &author, el.as_bytes())?;
+            alice.hash_and_insert(el, &author, el.as_bytes()).await?;
         }
 
         let mut bob = bob_store.new_replica(myspace.clone())?;
         for el in &bob_set {
-            bob.hash_and_insert(el, &author, el.as_bytes())?;
+            bob.hash_and_insert(el, &author, el.as_bytes()).await?;
         }
 
         sync(&mut alice, &mut bob).await?;
@@ -1866,8 +1884,9 @@ mod tests {
 
         let mut alice = alice_store.new_replica(myspace.clone())?;
         let mut bob = bob_store.new_replica(myspace.clone())?;
-        alice.delete_prefix("foo", &author)?;
-        bob.hash_and_insert("fooz", &author, "fooz".as_bytes())?;
+        alice.delete_prefix("foo", &author).await?;
+        bob.hash_and_insert("fooz", &author, "fooz".as_bytes())
+            .await?;
         sync(&mut alice, &mut bob).await?;
         check_entries(&mut alice_store, &myspace.id(), &author, &["fog", "fooz"])?;
         check_entries(&mut bob_store, &myspace.id(), &author, &["fog", "fooz"])?;
@@ -1876,27 +1895,27 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn test_replica_remove_memory() -> Result<()> {
+    #[tokio::test]
+    async fn test_replica_remove_memory() -> Result<()> {
         let alice_store = store::Store::memory();
-        test_replica_remove(alice_store)
+        test_replica_remove(alice_store).await
     }
 
-    #[test]
-    fn test_replica_remove_fs() -> Result<()> {
+    #[tokio::test]
+    async fn test_replica_remove_fs() -> Result<()> {
         let alice_dbfile = tempfile::NamedTempFile::new()?;
         let alice_store = store::fs::Store::persistent(alice_dbfile.path())?;
-        test_replica_remove(alice_store)
+        test_replica_remove(alice_store).await
     }
 
-    fn test_replica_remove(mut store: Store) -> Result<()> {
+    async fn test_replica_remove(mut store: Store) -> Result<()> {
         let mut rng = rand::rng();
         let namespace = NamespaceSecret::new(&mut rng);
         let author = Author::new(&mut rng);
         let mut replica = store.new_replica(namespace.clone())?;
 
         // insert entry
-        let hash = replica.hash_and_insert(b"foo", &author, b"bar")?;
+        let hash = replica.hash_and_insert(b"foo", &author, b"bar").await?;
         let res = store
             .get_many(namespace.id(), Query::all())?
             .collect::<Vec<_>>();
@@ -1919,7 +1938,7 @@ mod tests {
 
         // may recreate replica
         let mut replica = store.new_replica(namespace.clone())?;
-        replica.insert(b"foo", &author, hash, 3)?;
+        replica.insert(b"foo", &author, hash, 3).await?;
         let res = store
             .get_many(namespace.id(), Query::all())?
             .collect::<Vec<_>>();
@@ -1928,20 +1947,20 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn test_replica_delete_edge_cases_memory() -> Result<()> {
+    #[tokio::test]
+    async fn test_replica_delete_edge_cases_memory() -> Result<()> {
         let store = store::Store::memory();
-        test_replica_delete_edge_cases(store)
+        test_replica_delete_edge_cases(store).await
     }
 
-    #[test]
-    fn test_replica_delete_edge_cases_fs() -> Result<()> {
+    #[tokio::test]
+    async fn test_replica_delete_edge_cases_fs() -> Result<()> {
         let dbfile = tempfile::NamedTempFile::new()?;
         let store = store::fs::Store::persistent(dbfile.path())?;
-        test_replica_delete_edge_cases(store)
+        test_replica_delete_edge_cases(store).await
     }
 
-    fn test_replica_delete_edge_cases(mut store: Store) -> Result<()> {
+    async fn test_replica_delete_edge_cases(mut store: Store) -> Result<()> {
         let mut rng = rand::rng();
         let author = Author::new(&mut rng);
         let namespace = NamespaceSecret::new(&mut rng);
@@ -1956,23 +1975,23 @@ mod tests {
             for suffix in edgecases {
                 let key = [prefix, suffix].to_vec();
                 expected.push(key.clone());
-                replica.insert(&key, &author, hash, len)?;
+                replica.insert(&key, &author, hash, len).await?;
             }
             assert_keys(&mut store, namespace.id(), expected);
             let mut replica = store.new_replica(namespace.clone())?;
-            replica.delete_prefix([prefix], &author)?;
+            replica.delete_prefix([prefix], &author).await?;
             assert_keys(&mut store, namespace.id(), vec![]);
         }
 
         let mut replica = store.new_replica(namespace.clone())?;
         let key = vec![1u8, 0u8];
-        replica.insert(key, &author, hash, len)?;
+        replica.insert(key, &author, hash, len).await?;
         let key = vec![1u8, 1u8];
-        replica.insert(key, &author, hash, len)?;
+        replica.insert(key, &author, hash, len).await?;
         let key = vec![1u8, 2u8];
-        replica.insert(key, &author, hash, len)?;
+        replica.insert(key, &author, hash, len).await?;
         let prefix = vec![1u8, 1u8];
-        replica.delete_prefix(prefix, &author)?;
+        replica.delete_prefix(prefix, &author).await?;
         assert_keys(
             &mut store,
             namespace.id(),
@@ -1981,11 +2000,11 @@ mod tests {
 
         let mut replica = store.new_replica(namespace.clone())?;
         let key = vec![0u8, 255u8];
-        replica.insert(key, &author, hash, len)?;
+        replica.insert(key, &author, hash, len).await?;
         let key = vec![0u8, 0u8];
-        replica.insert(key, &author, hash, len)?;
+        replica.insert(key, &author, hash, len).await?;
         let prefix = vec![0u8];
-        replica.delete_prefix(prefix, &author)?;
+        replica.delete_prefix(prefix, &author).await?;
         assert_keys(
             &mut store,
             namespace.id(),
@@ -1995,27 +2014,27 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn test_latest_iter_memory() -> Result<()> {
+    #[tokio::test]
+    async fn test_latest_iter_memory() -> Result<()> {
         let store = store::Store::memory();
-        test_latest_iter(store)
+        test_latest_iter(store).await
     }
 
-    #[test]
-    fn test_latest_iter_fs() -> Result<()> {
+    #[tokio::test]
+    async fn test_latest_iter_fs() -> Result<()> {
         let dbfile = tempfile::NamedTempFile::new()?;
         let store = store::fs::Store::persistent(dbfile.path())?;
-        test_latest_iter(store)
+        test_latest_iter(store).await
     }
 
-    fn test_latest_iter(mut store: Store) -> Result<()> {
+    async fn test_latest_iter(mut store: Store) -> Result<()> {
         let mut rng = rand::rng();
         let author0 = Author::new(&mut rng);
         let author1 = Author::new(&mut rng);
         let namespace = NamespaceSecret::new(&mut rng);
         let mut replica = store.new_replica(namespace.clone())?;
 
-        replica.hash_and_insert(b"a0.1", &author0, b"hi")?;
+        replica.hash_and_insert(b"a0.1", &author0, b"hi").await?;
         let latest = store
             .get_latest_for_each_author(namespace.id())?
             .collect::<Result<Vec<_>>>()?;
@@ -2023,8 +2042,8 @@ mod tests {
         assert_eq!(latest[0].2, b"a0.1".to_vec());
 
         let mut replica = store.new_replica(namespace.clone())?;
-        replica.hash_and_insert(b"a1.1", &author1, b"hi")?;
-        replica.hash_and_insert(b"a0.2", &author0, b"hi")?;
+        replica.hash_and_insert(b"a1.1", &author1, b"hi").await?;
+        replica.hash_and_insert(b"a0.2", &author0, b"hi").await?;
         let latest = store
             .get_latest_for_each_author(namespace.id())?
             .collect::<Result<Vec<_>>>()?;
@@ -2035,24 +2054,24 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn test_replica_byte_keys_memory() -> Result<()> {
+    #[tokio::test]
+    async fn test_replica_byte_keys_memory() -> Result<()> {
         let store = store::Store::memory();
 
-        test_replica_byte_keys(store)?;
+        test_replica_byte_keys(store).await?;
         Ok(())
     }
 
-    #[test]
-    fn test_replica_byte_keys_fs() -> Result<()> {
+    #[tokio::test]
+    async fn test_replica_byte_keys_fs() -> Result<()> {
         let dbfile = tempfile::NamedTempFile::new()?;
         let store = store::fs::Store::persistent(dbfile.path())?;
-        test_replica_byte_keys(store)?;
+        test_replica_byte_keys(store).await?;
 
         Ok(())
     }
 
-    fn test_replica_byte_keys(mut store: Store) -> Result<()> {
+    async fn test_replica_byte_keys(mut store: Store) -> Result<()> {
         let mut rng = rand::rng();
         let author = Author::new(&mut rng);
         let namespace = NamespaceSecret::new(&mut rng);
@@ -2062,11 +2081,11 @@ mod tests {
 
         let key = vec![1u8, 0u8];
         let mut replica = store.new_replica(namespace.clone())?;
-        replica.insert(key, &author, hash, len)?;
+        replica.insert(key, &author, hash, len).await?;
         assert_keys(&mut store, namespace.id(), vec![vec![1u8, 0u8]]);
         let key = vec![1u8, 2u8];
         let mut replica = store.new_replica(namespace.clone())?;
-        replica.insert(key, &author, hash, len)?;
+        replica.insert(key, &author, hash, len).await?;
         assert_keys(
             &mut store,
             namespace.id(),
@@ -2075,7 +2094,7 @@ mod tests {
 
         let key = vec![0u8, 255u8];
         let mut replica = store.new_replica(namespace.clone())?;
-        replica.insert(key, &author, hash, len)?;
+        replica.insert(key, &author, hash, len).await?;
         assert_keys(
             &mut store,
             namespace.id(),
@@ -2085,21 +2104,21 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn test_replica_capability_memory() -> Result<()> {
+    #[tokio::test]
+    async fn test_replica_capability_memory() -> Result<()> {
         let store = store::Store::memory();
-        test_replica_capability(store)
+        test_replica_capability(store).await
     }
 
-    #[test]
-    fn test_replica_capability_fs() -> Result<()> {
+    #[tokio::test]
+    async fn test_replica_capability_fs() -> Result<()> {
         let dbfile = tempfile::NamedTempFile::new()?;
         let store = store::fs::Store::persistent(dbfile.path())?;
-        test_replica_capability(store)
+        test_replica_capability(store).await
     }
 
     #[allow(clippy::redundant_pattern_matching)]
-    fn test_replica_capability(mut store: Store) -> Result<()> {
+    async fn test_replica_capability(mut store: Store) -> Result<()> {
         let mut rng = rand_chacha::ChaCha12Rng::seed_from_u64(1);
         let author = store.new_author(&mut rng)?;
         let namespace = NamespaceSecret::new(&mut rng);
@@ -2108,18 +2127,18 @@ mod tests {
         let capability = Capability::Read(namespace.id());
         store.import_namespace(capability)?;
         let mut replica = store.open_replica(&namespace.id())?;
-        let res = replica.hash_and_insert(b"foo", &author, b"bar");
+        let res = replica.hash_and_insert(b"foo", &author, b"bar").await;
         assert!(matches!(res, Err(InsertError::ReadOnly)));
 
         // import write capability - insert must succeed
         let capability = Capability::Write(namespace.clone());
         store.import_namespace(capability)?;
         let mut replica = store.open_replica(&namespace.id())?;
-        let res = replica.hash_and_insert(b"foo", &author, b"bar");
+        let res = replica.hash_and_insert(b"foo", &author, b"bar").await;
         assert!(matches!(res, Ok(_)));
         store.close_replica(namespace.id());
         let mut replica = store.open_replica(&namespace.id())?;
-        let res = replica.hash_and_insert(b"foo", &author, b"bar");
+        let res = replica.hash_and_insert(b"foo", &author, b"bar").await;
         assert!(res.is_ok());
 
         // import read capability again - insert must still succeed
@@ -2127,7 +2146,7 @@ mod tests {
         store.import_namespace(capability)?;
         store.close_replica(namespace.id());
         let mut replica = store.open_replica(&namespace.id())?;
-        let res = replica.hash_and_insert(b"foo", &author, b"bar");
+        let res = replica.hash_and_insert(b"foo", &author, b"bar").await;
         assert!(res.is_ok());
         store.flush()?;
         Ok(())
@@ -2217,7 +2236,7 @@ mod tests {
         replica1.info.subscribe(events1_sender);
         replica2.info.subscribe(events2_sender);
 
-        replica1.hash_and_insert(b"foo", &author, b"init")?;
+        replica1.hash_and_insert(b"foo", &author, b"init").await?;
 
         let from1 = replica1.sync_initial_message()?;
         let from2 = replica2
@@ -2233,7 +2252,7 @@ mod tests {
         // now we will receive the entry from rpelica1. we will insert a newer entry now, while the
         // sync is already running. this means the entry from replica1 will be rejected. we make
         // sure that no InsertRemote event is emitted for this entry.
-        replica2.hash_and_insert(b"foo", &author, b"update")?;
+        replica2.hash_and_insert(b"foo", &author, b"update").await?;
         let from2 = replica2
             .sync_process_message(from1, peer1, &mut state2)
             .await
@@ -2254,24 +2273,24 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn test_replica_queries_mem() -> Result<()> {
+    #[tokio::test]
+    async fn test_replica_queries_mem() -> Result<()> {
         let store = store::Store::memory();
 
-        test_replica_queries(store)?;
+        test_replica_queries(store).await?;
         Ok(())
     }
 
-    #[test]
-    fn test_replica_queries_fs() -> Result<()> {
+    #[tokio::test]
+    async fn test_replica_queries_fs() -> Result<()> {
         let dbfile = tempfile::NamedTempFile::new()?;
         let store = store::fs::Store::persistent(dbfile.path())?;
-        test_replica_queries(store)?;
+        test_replica_queries(store).await?;
 
         Ok(())
     }
 
-    fn test_replica_queries(mut store: Store) -> Result<()> {
+    async fn test_replica_queries(mut store: Store) -> Result<()> {
         let mut rng = rand_chacha::ChaCha12Rng::seed_from_u64(1);
         let namespace = NamespaceSecret::new(&mut rng);
         let namespace_id = namespace.id();
@@ -2287,10 +2306,10 @@ mod tests {
         );
 
         let mut replica = store.new_replica(namespace.clone())?;
-        replica.hash_and_insert("hi/world", &a2, "a2")?;
-        replica.hash_and_insert("hi/world", &a1, "a1")?;
-        replica.hash_and_insert("hi/moon", &a2, "a1")?;
-        replica.hash_and_insert("hi", &a3, "a3")?;
+        replica.hash_and_insert("hi/world", &a2, "a2").await?;
+        replica.hash_and_insert("hi/world", &a1, "a1").await?;
+        replica.hash_and_insert("hi/moon", &a2, "a1").await?;
+        replica.hash_and_insert("hi", &a3, "a3").await?;
 
         struct QueryTester<'a> {
             store: &'a mut Store,
@@ -2420,7 +2439,7 @@ mod tests {
         );
 
         let mut replica = store.new_replica(namespace)?;
-        replica.delete_prefix("hi/world", &a2)?;
+        replica.delete_prefix("hi/world", &a2).await?;
         let mut qt = QueryTester {
             store: &mut store,
             namespace: namespace_id,

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1221,6 +1221,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "fs-store")]
     async fn test_basics_fs() -> Result<()> {
         let dbfile = tempfile::NamedTempFile::new()?;
         let store = store::fs::Store::persistent(dbfile.path())?;
@@ -1410,6 +1411,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "fs-store")]
     async fn test_content_hashes_iterator_fs() -> Result<()> {
         let dbfile = tempfile::NamedTempFile::new()?;
         let store = store::fs::Store::persistent(dbfile.path())?;
@@ -1537,6 +1539,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "fs-store")]
     async fn test_timestamps_fs() -> Result<()> {
         let dbfile = tempfile::NamedTempFile::new()?;
         let store = store::fs::Store::persistent(dbfile.path())?;
@@ -1600,6 +1603,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "fs-store")]
     async fn test_replica_sync_fs() -> Result<()> {
         let alice_dbfile = tempfile::NamedTempFile::new()?;
         let alice_store = store::fs::Store::persistent(alice_dbfile.path())?;
@@ -1653,6 +1657,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "fs-store")]
     async fn test_replica_timestamp_sync_fs() -> Result<()> {
         let alice_dbfile = tempfile::NamedTempFile::new()?;
         let alice_store = store::fs::Store::persistent(alice_dbfile.path())?;
@@ -1796,6 +1801,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "fs-store")]
     async fn test_prefix_delete_fs() -> Result<()> {
         let dbfile = tempfile::NamedTempFile::new()?;
         let store = store::fs::Store::persistent(dbfile.path())?;
@@ -1850,6 +1856,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "fs-store")]
     async fn test_replica_sync_delete_fs() -> Result<()> {
         let alice_dbfile = tempfile::NamedTempFile::new()?;
         let alice_store = store::fs::Store::persistent(alice_dbfile.path())?;
@@ -1902,6 +1909,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "fs-store")]
     async fn test_replica_remove_fs() -> Result<()> {
         let alice_dbfile = tempfile::NamedTempFile::new()?;
         let alice_store = store::fs::Store::persistent(alice_dbfile.path())?;
@@ -1954,6 +1962,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "fs-store")]
     async fn test_replica_delete_edge_cases_fs() -> Result<()> {
         let dbfile = tempfile::NamedTempFile::new()?;
         let store = store::fs::Store::persistent(dbfile.path())?;
@@ -2021,6 +2030,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "fs-store")]
     async fn test_latest_iter_fs() -> Result<()> {
         let dbfile = tempfile::NamedTempFile::new()?;
         let store = store::fs::Store::persistent(dbfile.path())?;
@@ -2063,6 +2073,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "fs-store")]
     async fn test_replica_byte_keys_fs() -> Result<()> {
         let dbfile = tempfile::NamedTempFile::new()?;
         let store = store::fs::Store::persistent(dbfile.path())?;
@@ -2111,6 +2122,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "fs-store")]
     async fn test_replica_capability_fs() -> Result<()> {
         let dbfile = tempfile::NamedTempFile::new()?;
         let store = store::fs::Store::persistent(dbfile.path())?;
@@ -2159,6 +2171,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "fs-store")]
     async fn test_actor_capability_fs() -> Result<()> {
         let dbfile = tempfile::NamedTempFile::new()?;
         let store = store::fs::Store::persistent(dbfile.path())?;
@@ -2282,6 +2295,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "fs-store")]
     async fn test_replica_queries_fs() -> Result<()> {
         let dbfile = tempfile::NamedTempFile::new()?;
         let store = store::fs::Store::persistent(dbfile.path())?;
@@ -2470,6 +2484,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "fs-store")]
     fn test_dl_policies_fs() -> Result<()> {
         let dbfile = tempfile::NamedTempFile::new()?;
         let mut store = store::fs::Store::persistent(dbfile.path())?;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -6,7 +6,6 @@
 //
 // This is going to change!
 
-use n0_future::{time::SystemTime, IterExt};
 use std::{
     cmp::Ordering,
     fmt::Debug,
@@ -18,6 +17,7 @@ use std::{
 use bytes::{Bytes, BytesMut};
 use ed25519_dalek::{Signature, SignatureError};
 use iroh_blobs::Hash;
+use n0_future::{time::SystemTime, IterExt};
 use serde::{Deserialize, Serialize};
 
 pub use crate::heads::AuthorHeads;

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -216,7 +216,7 @@ async fn test_default_author_persist() -> TestResult<()> {
         // somehow the blob store is not shutdown correctly (yet?) on macos.
         // so we give it some time until we find a proper fix.
         #[cfg(target_os = "macos")]
-    n0_future::time::sleep(std::time::Duration::from_secs(1)).await;
+        n0_future::time::sleep(std::time::Duration::from_secs(1)).await;
 
         tokio::fs::remove_file(iroh_root.join("default-author")).await?;
         drop(iroh);

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -31,7 +31,7 @@ async fn test_doc_close() -> Result<()> {
     // dropping doc1 will close the doc if not already closed
     // wait a bit because the close-on-drop spawns a task for which we cannot track completion.
     drop(doc1);
-    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    n0_future::time::sleep(n0_future::time::Duration::from_millis(100)).await;
 
     // operations on doc2 still succeed
     doc2.set_bytes(author, "foo", "bar").await?;
@@ -216,7 +216,7 @@ async fn test_default_author_persist() -> TestResult<()> {
         // somehow the blob store is not shutdown correctly (yet?) on macos.
         // so we give it some time until we find a proper fix.
         #[cfg(target_os = "macos")]
-        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    n0_future::time::sleep(std::time::Duration::from_secs(1)).await;
 
         tokio::fs::remove_file(iroh_root.join("default-author")).await?;
         drop(iroh);

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -167,6 +167,7 @@ async fn test_default_author_memory() -> Result<()> {
 
 #[tokio::test]
 #[traced_test]
+#[cfg(feature = "fs-store")]
 async fn test_default_author_persist() -> TestResult<()> {
     let iroh_root_dir = tempfile::TempDir::new()?;
     let iroh_root = iroh_root_dir.path();

--- a/tests/gc.rs
+++ b/tests/gc.rs
@@ -1,3 +1,5 @@
+#![allow(unused)]
+
 use std::{path::PathBuf, time::Duration};
 
 use anyhow::Result;
@@ -18,6 +20,7 @@ pub fn create_test_data(size: usize) -> Bytes {
 }
 
 /// Wrap a bao store in a node that has gc enabled.
+#[cfg(feature = "fs-store")]
 async fn persistent_node(
     path: PathBuf,
     gc_period: Duration,
@@ -35,6 +38,7 @@ async fn persistent_node(
 }
 
 #[tokio::test]
+#[cfg(feature = "fs-store")]
 async fn redb_doc_import_stress() -> Result<()> {
     let _ = tracing_subscriber::fmt::try_init();
     let dir = testdir!();

--- a/tests/gc.rs
+++ b/tests/gc.rs
@@ -1,11 +1,12 @@
 #![allow(unused)]
 
-use std::{path::PathBuf, time::Duration};
+use std::path::PathBuf;
 
 use anyhow::Result;
 use bytes::Bytes;
 use futures_lite::StreamExt;
 use iroh_blobs::api::blobs::ImportMode;
+use n0_future::time::Duration;
 use rand::RngCore;
 use testdir::testdir;
 use util::Node;

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -1,9 +1,4 @@
-use std::{
-    collections::HashMap,
-    future::Future,
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::{collections::HashMap, future::Future, sync::Arc, time::Duration};
 
 use anyhow::{anyhow, bail, Context, Result};
 use bytes::Bytes;
@@ -20,6 +15,7 @@ use iroh_docs::{
     store::{DownloadPolicy, FilterKind, Query},
     AuthorId, ContentStatus, Entry,
 };
+use n0_future::time::Instant;
 use rand::{CryptoRng, Rng, SeedableRng};
 use tempfile::tempdir;
 use tracing::{debug, error_span, info, Instrument};

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -140,7 +140,7 @@ async fn sync_subscribe_no_sync() -> Result<()> {
     let mut sub = doc.subscribe().await?;
     let author = client.docs().author_create().await?;
     doc.set_bytes(author, b"k".to_vec(), b"v".to_vec()).await?;
-    let event = tokio::time::timeout(Duration::from_millis(100), sub.next()).await?;
+    let event = n0_future::time::timeout(Duration::from_millis(100), sub.next()).await?;
     assert!(
         matches!(event, Some(Ok(LiveEvent::InsertLocal { .. }))),
         "expected InsertLocal but got {event:?}"
@@ -657,7 +657,7 @@ async fn sync_restart_node() -> Result<()> {
     info!(me = %id1.fmt_short(), "node1 down");
 
     info!(me = %id1.fmt_short(), "sleep 1s");
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    n0_future::time::sleep(Duration::from_secs(1)).await;
 
     info!(me = %id2.fmt_short(), "node2 set b");
     let hash_b = doc2.set_bytes(author2, "n2/b", "b").await?;
@@ -843,7 +843,7 @@ async fn test_download_policies() -> Result<()> {
         (downloaded_a, downloaded_b)
     };
 
-    let (downloaded_a, mut downloaded_b) = tokio::time::timeout(TIMEOUT, fut)
+    let (downloaded_a, mut downloaded_b) = n0_future::time::timeout(TIMEOUT, fut)
         .await
         .context("timeout elapsed")?;
 
@@ -874,7 +874,7 @@ async fn sync_big() -> Result<()> {
 
     tokio::task::spawn(async move {
         for i in 0.. {
-            tokio::time::sleep(Duration::from_secs(1)).await;
+            n0_future::time::sleep(Duration::from_secs(1)).await;
             info!("tick {i}");
         }
     });
@@ -1012,7 +1012,7 @@ async fn test_list_docs_stream() -> testresult::TestResult<()> {
         }
     };
 
-    tokio::time::timeout(Duration::from_secs(2), fut)
+    n0_future::time::timeout(Duration::from_secs(2), fut)
         .await
         .expect("not to timeout");
 
@@ -1081,7 +1081,7 @@ async fn wait_for_events(
     matcher: impl Fn(&LiveEvent) -> bool,
 ) -> anyhow::Result<Vec<LiveEvent>> {
     let mut res = Vec::with_capacity(count);
-    let sleep = tokio::time::sleep(timeout);
+    let sleep = n0_future::time::sleep(timeout);
     tokio::pin!(sleep);
     while res.len() < count {
         tokio::select! {
@@ -1184,7 +1184,7 @@ async fn doc_delete() -> Result<()> {
 
     // wait for gc
     // TODO: allow to manually trigger gc
-    tokio::time::sleep(Duration::from_secs(2)).await;
+    n0_future::time::sleep(Duration::from_secs(2)).await;
     let bytes = client.blobs().get_bytes(hash).await;
     assert!(bytes.is_err());
     node.shutdown().await?;
@@ -1289,7 +1289,7 @@ async fn assert_next<T: std::fmt::Debug + Clone>(
         }
         items
     };
-    let res = tokio::time::timeout(timeout, fut).await;
+    let res = n0_future::time::timeout(timeout, fut).await;
     res.expect("timeout reached")
 }
 
@@ -1357,7 +1357,7 @@ async fn assert_next_unordered_with_optionals<T: std::fmt::Debug + Clone>(
         Ok(())
     };
     tokio::pin!(fut);
-    let res = tokio::time::timeout(timeout, fut)
+    let res = n0_future::time::timeout(timeout, fut)
         .await
         .map_err(|_| anyhow!("Timeout reached ({timeout:?})"))
         .and_then(|res| res);

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, future::Future, sync::Arc, time::Duration};
+use std::{collections::HashMap, future::Future, sync::Arc};
 
 use anyhow::{anyhow, bail, Context, Result};
 use bytes::Bytes;
@@ -15,7 +15,7 @@ use iroh_docs::{
     store::{DownloadPolicy, FilterKind, Query},
     AuthorId, ContentStatus, Entry,
 };
-use n0_future::time::Instant;
+use n0_future::time::{Duration, Instant};
 use rand::{CryptoRng, Rng, SeedableRng};
 #[cfg(feature = "fs-store")]
 use tempfile::tempdir;

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -17,6 +17,7 @@ use iroh_docs::{
 };
 use n0_future::time::Instant;
 use rand::{CryptoRng, Rng, SeedableRng};
+#[cfg(feature = "fs-store")]
 use tempfile::tempdir;
 use tracing::{debug, error_span, info, Instrument};
 use tracing_test::traced_test;
@@ -584,6 +585,7 @@ async fn test_sync_via_relay() -> Result<()> {
 #[tokio::test]
 #[traced_test]
 #[ignore = "flaky"]
+#[cfg(feature = "fs-store")]
 async fn sync_restart_node() -> Result<()> {
     let mut rng = test_rng(b"sync_restart_node");
     let (relay_map, _relay_url, _guard) = iroh::test_utils::run_relay_server().await?;
@@ -1156,6 +1158,7 @@ impl PartialEq<ExpectedEntry> for (Entry, Bytes) {
 
 #[tokio::test]
 #[traced_test]
+#[cfg(feature = "fs-store")]
 async fn doc_delete() -> Result<()> {
     let tempdir = tempdir()?;
     // TODO(Frando): iroh-blobs has gc only for fs store atm, change test to test both

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -110,7 +110,7 @@ async fn sync_simple() -> Result<()> {
     assert_latest(blobs1, &doc1, b"k1", b"v1").await;
 
     info!("node0: assert 2 events");
-    assert_next(
+    assert_next_unordered(
         &mut events0,
         TIMEOUT,
         vec![

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -116,6 +116,7 @@ async fn sync_simple() -> Result<()> {
         vec![
             Box::new(move |e| matches!(e, LiveEvent::NeighborUp(peer) if *peer == peer1)),
             Box::new(move |e| match_sync_finished(e, peer1)),
+            match_event!(LiveEvent::PendingContentReady),
         ],
     )
     .await;

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -1,4 +1,5 @@
-#![allow(dead_code)]
+#![allow(unused)]
+
 use std::{
     net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6},
     ops::Deref,

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -67,7 +67,7 @@ pub struct Builder {
     use_n0_discovery: bool,
     storage: Storage,
     // node_discovery: Option<Box<dyn Discovery>>,
-    gc_interval: Option<std::time::Duration>,
+    gc_interval: Option<n0_future::time::Duration>,
     #[debug(skip)]
     register_gc_done_cb: Option<Box<dyn Fn() + Send + 'static>>,
     bind_random_port: bool,
@@ -165,7 +165,7 @@ impl Builder {
         self
     }
 
-    pub fn gc_interval(mut self, value: Option<std::time::Duration>) -> Self {
+    pub fn gc_interval(mut self, value: Option<n0_future::time::Duration>) -> Self {
         self.gc_interval = value;
         self
     }


### PR DESCRIPTION
## Description

Make iroh-docs work in WebAssembly in the browser, memstore only.


* Has the usual changes to use `n0-future` for time and tasks.
* `redb` works in-memory in the browser. No persistent store for now. In native environments, we spawn a separate thread for the storage actor with a single-threaded tokio runtime. In wasm, we instead simply run this on the main thread. With the inmemory store this is fine,  IMO.
* This PR includes a refactor that was needed anyway: A couple of methods on `Replica` are now async because we previously used `send_blocking` on a `async_channel::Sender` (uuh) and `async_channel::Sender::send_blocking` is not available on wasm. 

## Breaking Changes

Made a couple of methods on `Replica` async because we previously used `send_blocking` on a `async_channel::Sender` (uuh) and `async_channel::Sender::send_blocking` is not available on wasm. This is a much needed refactor anyways.

(needs more details)

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
