### PR TITLE
fix: retry incomplete blob downloads after sync

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -60,6 +60,7 @@ impl Engine {
     ///
     /// This will spawn two tokio tasks for the live sync coordination and gossip actors, and a
     /// thread for the actor interacting with doc storage.
+    #[allow(clippy::too_many_arguments)]
     pub async fn spawn(
         endpoint: Endpoint,
         gossip: Gossip,
@@ -68,6 +69,7 @@ impl Engine {
         downloader: Downloader,
         default_author_storage: DefaultAuthorStorage,
         protect_cb: Option<ProtectCallbackHandler>,
+        incomplete_blob_check_interval: Option<std::time::Duration>,
     ) -> anyhow::Result<Self> {
         let (live_actor_tx, to_live_actor_recv) = mpsc::channel(ACTOR_CHANNEL_CAP);
         let me = endpoint.id().fmt_short().to_string();
@@ -122,6 +124,7 @@ impl Engine {
             to_live_actor_recv,
             live_actor_tx.clone(),
             sync.metrics().clone(),
+            incomplete_blob_check_interval,
         )?;
         let actor_handle = n0_future::task::spawn(
             async move {

--- a/src/engine/live.rs
+++ b/src/engine/live.rs
@@ -32,6 +32,7 @@ use crate::{
         connect_and_sync, handle_connection, AbortReason, AcceptError, AcceptOutcome, ConnectError,
         SyncFinished,
     },
+    store::Query,
     AuthorHeads, ContentStatus, NamespaceId, SignedEntry,
 };
 
@@ -583,6 +584,9 @@ impl LiveActor {
                         }
                     }
                 }
+
+                // Queue downloads for entries with incomplete blobs.
+                self.check_incomplete_blobs(namespace, peer).await;
             }
         };
 
@@ -740,6 +744,52 @@ impl LiveActor {
         }
 
         Ok(())
+    }
+
+    /// Scan a namespace for entries whose blobs are not yet complete and queue downloads.
+    ///
+    /// This is called after a successful sync so that blobs that were missed on earlier
+    /// syncs (e.g. because the first peer lacked the content, or due to a restart losing
+    /// the in-memory `missing_hashes` set) get another download attempt with `peer` as a
+    /// candidate provider.
+    async fn check_incomplete_blobs(&mut self, namespace: NamespaceId, peer: PublicKey) {
+        let policy = match self.sync.get_download_policy(namespace).await {
+            Ok(policy) => policy,
+            Err(e) => {
+                warn!(%e, "failed to get download policy for incomplete blob check");
+                return;
+            }
+        };
+
+        let (tx, mut rx) = irpc::channel::mpsc::channel::<crate::api::RpcResult<SignedEntry>>(64);
+        if let Err(e) = self
+            .sync
+            .get_many(namespace, Query::all().build(), tx)
+            .await
+        {
+            warn!(%e, "failed to get entries for incomplete blob check");
+            return;
+        }
+
+        let mut queued = 0u64;
+        while let Ok(Some(entry_result)) = rx.recv().await {
+            let entry = match entry_result {
+                Ok(entry) => entry,
+                Err(_) => continue,
+            };
+            if !policy.matches(entry.entry()) {
+                continue;
+            }
+            if entry.content_len() == 0 {
+                continue;
+            }
+            let hash = entry.content_hash();
+            self.start_download(namespace, hash, peer, false).await;
+            queued += 1;
+        }
+        if queued > 0 {
+            debug!(namespace=%namespace.fmt_short(), %queued, "queued incomplete blob downloads after sync");
+        }
     }
 
     async fn start_download(

--- a/src/engine/live.rs
+++ b/src/engine/live.rs
@@ -31,6 +31,7 @@ use crate::{
         connect_and_sync, handle_connection, AbortReason, AcceptError, AcceptOutcome, ConnectError,
         SyncFinished,
     },
+    store::Query,
     AuthorHeads, ContentStatus, NamespaceId, SignedEntry,
 };
 
@@ -582,6 +583,9 @@ impl LiveActor {
                         }
                     }
                 }
+
+                // Queue downloads for entries with incomplete blobs.
+                self.check_incomplete_blobs(namespace, peer).await;
             }
         };
 
@@ -739,6 +743,52 @@ impl LiveActor {
         }
 
         Ok(())
+    }
+
+    /// Scan a namespace for entries whose blobs are not yet complete and queue downloads.
+    ///
+    /// This is called after a successful sync so that blobs that were missed on earlier
+    /// syncs (e.g. because the first peer lacked the content, or due to a restart losing
+    /// the in-memory `missing_hashes` set) get another download attempt with `peer` as a
+    /// candidate provider.
+    async fn check_incomplete_blobs(&mut self, namespace: NamespaceId, peer: PublicKey) {
+        let policy = match self.sync.get_download_policy(namespace).await {
+            Ok(policy) => policy,
+            Err(e) => {
+                warn!(%e, "failed to get download policy for incomplete blob check");
+                return;
+            }
+        };
+
+        let (tx, mut rx) = irpc::channel::mpsc::channel::<crate::api::RpcResult<SignedEntry>>(64);
+        if let Err(e) = self
+            .sync
+            .get_many(namespace, Query::all().build(), tx)
+            .await
+        {
+            warn!(%e, "failed to get entries for incomplete blob check");
+            return;
+        }
+
+        let mut queued = 0u64;
+        while let Ok(Some(entry_result)) = rx.recv().await {
+            let entry = match entry_result {
+                Ok(entry) => entry,
+                Err(_) => continue,
+            };
+            if !policy.matches(entry.entry()) {
+                continue;
+            }
+            if entry.content_len() == 0 {
+                continue;
+            }
+            let hash = entry.content_hash();
+            self.start_download(namespace, hash, peer, false).await;
+            queued += 1;
+        }
+        if queued > 0 {
+            debug!(namespace=%namespace.fmt_short(), %queued, "queued incomplete blob downloads after sync");
+        }
     }
 
     async fn start_download(

--- a/src/engine/live.rs
+++ b/src/engine/live.rs
@@ -173,6 +173,12 @@ pub struct LiveActor {
     queued_hashes: QueuedHashes,
     /// Nodes known to have a hash
     hash_providers: ProviderNodes,
+    /// Per-blob backoff so a blob with no provider isn't re-requested on every re-scan.
+    blob_recheck_backoff: HashMap<Hash, BlobRecheckBackoff>,
+    /// Last incomplete-blob scan time per (namespace, peer), to debounce the scan.
+    last_incomplete_check: HashMap<(NamespaceId, PublicKey), n0_future::time::Instant>,
+    /// Minimum interval between incomplete-blob scans per (namespace, peer); zero scans every sync.
+    incomplete_blob_check_interval: std::time::Duration,
 
     /// Subscribers to actor events
     subscribers: SubscribersMap,
@@ -193,6 +199,7 @@ impl LiveActor {
         inbox: mpsc::Receiver<ToLiveActor>,
         sync_actor_tx: mpsc::Sender<ToLiveActor>,
         metrics: Arc<Metrics>,
+        incomplete_blob_check_interval: Option<std::time::Duration>,
     ) -> Result<Self> {
         let (replica_events_tx, replica_events_rx) = async_channel::bounded(1024);
         let gossip_state = GossipState::new(gossip, sync.clone(), sync_actor_tx.clone());
@@ -217,6 +224,10 @@ impl LiveActor {
             missing_hashes: Default::default(),
             queued_hashes: Default::default(),
             hash_providers: Default::default(),
+            blob_recheck_backoff: Default::default(),
+            last_incomplete_check: Default::default(),
+            incomplete_blob_check_interval: incomplete_blob_check_interval
+                .unwrap_or(DEFAULT_INCOMPLETE_BLOB_CHECK_DEBOUNCE),
             metrics,
         })
     }
@@ -655,6 +666,8 @@ impl LiveActor {
         let completed_namespaces = self.queued_hashes.remove_hash(&hash);
         debug!(namespace=%namespace.fmt_short(), success=res.is_ok(), completed_namespaces=completed_namespaces.len(), "download ready");
         if res.is_ok() {
+            // Recovered: drop the re-request backoff.
+            self.blob_recheck_backoff.remove(&hash);
             self.subscribers
                 .send(&namespace, Event::ContentReady { hash })
                 .await;
@@ -752,6 +765,17 @@ impl LiveActor {
     /// the in-memory `missing_hashes` set) get another download attempt with `peer` as a
     /// candidate provider.
     async fn check_incomplete_blobs(&mut self, namespace: NamespaceId, peer: PublicKey) {
+        // Debounce per (namespace, peer): a newly-synced peer scans promptly, repeated syncs with
+        // the same peer collapse.
+        let debounce_key = (namespace, peer);
+        if let Some(last) = self.last_incomplete_check.get(&debounce_key) {
+            if last.elapsed() < self.incomplete_blob_check_interval {
+                return;
+            }
+        }
+        self.last_incomplete_check
+            .insert(debounce_key, n0_future::time::Instant::now());
+
         let policy = match self.sync.get_download_policy(namespace).await {
             Ok(policy) => policy,
             Err(e) => {
@@ -783,8 +807,27 @@ impl LiveActor {
                 continue;
             }
             let hash = entry.content_hash();
-            self.start_download(namespace, hash, peer, false).await;
-            queued += 1;
+            // Already complete: drop any stale backoff.
+            if matches!(
+                self.bao_store.blobs().status(hash).await,
+                Ok(BlobStatus::Complete { .. })
+            ) {
+                self.blob_recheck_backoff.remove(&hash);
+                continue;
+            }
+            // Always try a peer not yet offered for this hash ("retry from second peer"); only
+            // back off re-requests to peers already tried.
+            let untried_peer = !self.hash_providers.contains(&hash, &peer);
+            if untried_peer
+                || self
+                    .blob_recheck_backoff
+                    .entry(hash)
+                    .or_default()
+                    .should_request(MAX_BLOB_RECHECK_BACKOFF)
+            {
+                self.start_download(namespace, hash, peer, false).await;
+                queued += 1;
+            }
         }
         if queued > 0 {
             debug!(namespace=%namespace.fmt_short(), %queued, "queued incomplete blob downloads after sync");
@@ -945,8 +988,49 @@ struct QueuedHashes {
     by_namespace: HashMap<NamespaceId, HashSet<Hash>>,
 }
 
+/// Default interval for the after-sync incomplete-blob scan when the builder does not override it.
+const DEFAULT_INCOMPLETE_BLOB_CHECK_DEBOUNCE: std::time::Duration =
+    std::time::Duration::from_secs(30);
+
+/// Cap, in re-scan passes, on the per-blob re-request backoff window.
+const MAX_BLOB_RECHECK_BACKOFF: u32 = 64;
+
+/// Per-blob exponential backoff for the incomplete-blob re-scan: request, then skip a doubling
+/// number of passes (capped at [`MAX_BLOB_RECHECK_BACKOFF`]) before the next request.
+#[derive(Debug, Default)]
+struct BlobRecheckBackoff {
+    /// Remaining re-scan passes to skip before the next re-request.
+    skip: u32,
+    /// Current backoff window in passes; doubles after each re-request up to the cap.
+    window: u32,
+}
+
+impl BlobRecheckBackoff {
+    /// Advance one re-scan pass; return whether the blob should be re-requested now.
+    fn should_request(&mut self, max_window: u32) -> bool {
+        if self.skip > 0 {
+            self.skip -= 1;
+            return false;
+        }
+        self.window = self.window.saturating_mul(2).clamp(1, max_window);
+        self.skip = self.window;
+        true
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 struct ProviderNodes(Arc<std::sync::Mutex<HashMap<Hash, HashSet<EndpointId>>>>);
+
+impl ProviderNodes {
+    /// Whether `node` has already been recorded as a candidate provider for `hash`.
+    fn contains(&self, hash: &Hash, node: &EndpointId) -> bool {
+        self.0
+            .lock()
+            .expect("poisoned")
+            .get(hash)
+            .is_some_and(|nodes| nodes.contains(node))
+    }
+}
 
 impl ContentDiscovery for ProviderNodes {
     fn find_providers(&self, hash: HashAndFormat) -> n0_future::stream::Boxed<EndpointId> {
@@ -1052,5 +1136,14 @@ mod tests {
         drop(a_rx);
         drop(b_rx);
         subscribers.send(Event::NeighborUp(pk)).await;
+    }
+
+    #[test]
+    fn blob_recheck_backoff_is_exponential_and_capped() {
+        let max = 8;
+        let mut b = BlobRecheckBackoff::default();
+        let requested: Vec<u32> = (0..30).filter(|_| b.should_request(max)).collect();
+        // First pass requests, then gaps double (1, 2, 4, 8) and stay capped at 8.
+        assert_eq!(requested, vec![0, 2, 5, 10, 19, 28]);
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -40,7 +40,7 @@ impl Docs {
     pub fn persistent(path: std::path::PathBuf) -> Builder {
         Builder {
             storage: Storage::Persistent(path),
-            protect_cb: None,
+            ..Default::default()
         }
     }
 
@@ -86,9 +86,19 @@ impl ProtocolHandler for Docs {
 pub struct Builder {
     storage: Storage,
     protect_cb: Option<ProtectCallbackHandler>,
+    incomplete_blob_check_interval: Option<std::time::Duration>,
 }
 
 impl Builder {
+    /// Minimum interval between the after-sync incomplete-blob scans of a namespace, per sync peer.
+    ///
+    /// If unset, a default debounce is used; pass [`Duration::ZERO`](std::time::Duration::ZERO) to
+    /// scan after every sync.
+    pub fn incomplete_blob_check_interval(mut self, interval: std::time::Duration) -> Self {
+        self.incomplete_blob_check_interval = Some(interval);
+        self
+    }
+
     /// Set the garbage collection protection handler for blobs.
     ///
     /// See [`ProtectCallbackHandler::new`] for details.
@@ -125,6 +135,7 @@ impl Builder {
             downloader,
             author_store,
             self.protect_cb,
+            self.incomplete_blob_check_interval,
         )
         .await?;
         Ok(Docs::new(engine))

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -1223,6 +1223,432 @@ async fn sync_drop_doc() -> Result<()> {
     Ok(())
 }
 
+/// Peer B first syncs with peer C (who has metadata but no blob), then syncs with peer A
+/// (who has the blob). Without the incomplete-blob retry after sync, B would never download.
+#[tokio::test]
+#[traced_test]
+async fn sync_retries_blob_from_second_peer() -> Result<()> {
+    let mut rng = test_rng(b"sync_retries_blob_from_second_peer");
+    let nodes = spawn_nodes(3, &mut rng).await?;
+    let clients = nodes.iter().map(|node| node.client()).collect::<Vec<_>>();
+
+    // A creates a doc and writes a key
+    let author_a = clients[0].docs().author_create().await?;
+    let doc_a = clients[0].docs().create().await?;
+    let hash = doc_a
+        .set_bytes(author_a, b"key1".to_vec(), b"value1".to_vec())
+        .await?;
+
+    let mut ticket = doc_a
+        .share(ShareMode::Write, AddrInfoOptions::RelayAndAddresses)
+        .await?;
+    let addr_a = ticket.nodes[0].clone();
+    // unset peers to not yet start sync
+    ticket.nodes = vec![];
+
+    // C joins with NothingExcept policy, syncs with A (metadata only, no blob)
+    info!("C: import and sync with A");
+    let doc_c = clients[2].docs().import(ticket.clone()).await?;
+    doc_c
+        .set_download_policy(DownloadPolicy::NothingExcept(vec![]))
+        .await?;
+    let mut events_c = doc_c.subscribe().await?;
+    doc_c.start_sync(vec![addr_a.clone()]).await?;
+    assert_next_unordered_with_optionals(
+        &mut events_c,
+        TIMEOUT,
+        vec![
+            match_event!(LiveEvent::InsertRemote { .. }),
+            match_event!(LiveEvent::SyncFinished(_)),
+        ],
+        vec![
+            match_event!(LiveEvent::NeighborUp(_)),
+            match_event!(LiveEvent::PendingContentReady),
+        ],
+    )
+    .await;
+
+    // B joins and syncs with C only — gets entry metadata but C has no blob to offer
+    info!("B: import and sync with C");
+    let ticket_c = doc_c
+        .share(ShareMode::Write, AddrInfoOptions::RelayAndAddresses)
+        .await?;
+    let addr_c = ticket_c.nodes[0].clone();
+
+    let doc_b = clients[1].docs().import(ticket.clone()).await?;
+    let blobs_b = clients[1].blobs();
+    let mut events_b = doc_b.subscribe().await?;
+
+    doc_b.start_sync(vec![addr_c]).await?;
+    assert_next_unordered_with_optionals(
+        &mut events_b,
+        TIMEOUT,
+        vec![
+            match_event!(LiveEvent::InsertRemote { .. }),
+            match_event!(LiveEvent::SyncFinished(_)),
+        ],
+        vec![
+            match_event!(LiveEvent::NeighborUp(_)),
+            match_event!(LiveEvent::NeighborUp(_)),
+            match_event!(LiveEvent::SyncFinished(_)),
+            match_event!(LiveEvent::PendingContentReady),
+            match_event!(LiveEvent::PendingContentReady),
+        ],
+    )
+    .await;
+
+    // B has the entry but not the blob
+    assert!(blobs_b.get_bytes(hash).await.is_err());
+
+    // B syncs with A — the post-sync incomplete blob check should discover and download it
+    info!("B: sync with A");
+    doc_b.start_sync(vec![addr_a]).await?;
+
+    assert_next_unordered_with_optionals(
+        &mut events_b,
+        TIMEOUT,
+        vec![Box::new(
+            move |e| matches!(e, LiveEvent::ContentReady { hash: h } if *h == hash),
+        )],
+        vec![
+            match_event!(LiveEvent::NeighborUp(_)),
+            match_event!(LiveEvent::NeighborUp(_)),
+            match_event!(LiveEvent::SyncFinished(_)),
+            match_event!(LiveEvent::SyncFinished(_)),
+            match_event!(LiveEvent::SyncFinished(_)),
+            match_event!(LiveEvent::PendingContentReady),
+            match_event!(LiveEvent::PendingContentReady),
+            match_event!(LiveEvent::PendingContentReady),
+        ],
+    )
+    .await;
+
+    assert_latest(blobs_b, &doc_b, b"key1", b"value1").await;
+
+    for node in nodes {
+        node.shutdown().await?;
+    }
+    Ok(())
+}
+
+/// After changing the download policy to include previously excluded keys, a re-sync should
+/// trigger downloads for those entries.
+#[tokio::test]
+#[traced_test]
+async fn sync_retries_blob_after_policy_change() -> Result<()> {
+    let mut rng = test_rng(b"sync_retries_blob_after_policy_change");
+    let nodes = spawn_nodes(2, &mut rng).await?;
+    let clients = nodes.iter().map(|node| node.client()).collect::<Vec<_>>();
+
+    // A writes two keys
+    let author_a = clients[0].docs().author_create().await?;
+    let doc_a = clients[0].docs().create().await?;
+    let hash_inc = doc_a
+        .set_bytes(author_a, b"included".to_vec(), b"yes".to_vec())
+        .await?;
+    let hash_exc = doc_a
+        .set_bytes(author_a, b"excluded".to_vec(), b"no".to_vec())
+        .await?;
+
+    let mut ticket = doc_a
+        .share(ShareMode::Write, AddrInfoOptions::RelayAndAddresses)
+        .await?;
+    let addr_a = ticket.nodes[0].clone();
+    // unset peers to not yet start sync
+    ticket.nodes = vec![];
+
+    // B joins with NothingExcept("included"), syncs with A
+    info!("B: import and sync with policy NothingExcept(included)");
+    let doc_b = clients[1].docs().import(ticket).await?;
+    let blobs_b = clients[1].blobs();
+    doc_b
+        .set_download_policy(DownloadPolicy::NothingExcept(vec![FilterKind::Exact(
+            "included".into(),
+        )]))
+        .await?;
+    let mut events_b = doc_b.subscribe().await?;
+
+    doc_b.start_sync(vec![addr_a.clone()]).await?;
+
+    // B gets both entries but only downloads "included"
+    assert_next_unordered_with_optionals(
+        &mut events_b,
+        TIMEOUT,
+        vec![
+            match_event!(LiveEvent::InsertRemote { .. }),
+            match_event!(LiveEvent::InsertRemote { .. }),
+            Box::new(move |e| matches!(e, LiveEvent::ContentReady { hash } if *hash == hash_inc)),
+        ],
+        vec![
+            match_event!(LiveEvent::NeighborUp(_)),
+            match_event!(LiveEvent::SyncFinished(_)),
+            match_event!(LiveEvent::SyncFinished(_)),
+            match_event!(LiveEvent::PendingContentReady),
+            match_event!(LiveEvent::PendingContentReady),
+        ],
+    )
+    .await;
+
+    assert_latest(blobs_b, &doc_b, b"included", b"yes").await;
+    assert!(blobs_b.get_bytes(hash_exc).await.is_err());
+
+    // B changes policy to download everything and re-syncs
+    info!("B: change policy to EverythingExcept and re-sync");
+    doc_b
+        .set_download_policy(DownloadPolicy::EverythingExcept(vec![]))
+        .await?;
+    doc_b.start_sync(vec![addr_a]).await?;
+
+    // the post-sync incomplete blob check should now download the previously excluded blob
+    assert_next_unordered_with_optionals(
+        &mut events_b,
+        TIMEOUT,
+        vec![Box::new(
+            move |e| matches!(e, LiveEvent::ContentReady { hash } if *hash == hash_exc),
+        )],
+        vec![
+            match_event!(LiveEvent::NeighborUp(_)),
+            match_event!(LiveEvent::SyncFinished(_)),
+            match_event!(LiveEvent::SyncFinished(_)),
+            match_event!(LiveEvent::PendingContentReady),
+            match_event!(LiveEvent::PendingContentReady),
+        ],
+    )
+    .await;
+
+    assert_latest(blobs_b, &doc_b, b"excluded", b"no").await;
+
+    for node in nodes {
+        node.shutdown().await?;
+    }
+    Ok(())
+}
+
+/// When B downloads a previously missing blob after syncing with A, C (also missing the blob)
+/// can fetch it from B by syncing with B.
+#[tokio::test]
+#[traced_test]
+async fn sync_retries_missing_blob_propagates_content_ready() -> Result<()> {
+    let mut rng = test_rng(b"sync_retries_propagation");
+    let nodes = spawn_nodes(3, &mut rng).await?;
+    let clients = nodes.iter().map(|node| node.client()).collect::<Vec<_>>();
+
+    // A creates a doc and writes a key
+    let author_a = clients[0].docs().author_create().await?;
+    let doc_a = clients[0].docs().create().await?;
+    let hash = doc_a
+        .set_bytes(author_a, b"data".to_vec(), b"hello".to_vec())
+        .await?;
+
+    let mut ticket = doc_a
+        .share(ShareMode::Write, AddrInfoOptions::RelayAndAddresses)
+        .await?;
+    let addr_a = ticket.nodes[0].clone();
+    // unset peers to not yet start sync
+    ticket.nodes = vec![];
+
+    // C joins with NothingExcept policy, syncs with A (metadata only, no blob)
+    info!("C: import and sync with A");
+    let doc_c = clients[2].docs().import(ticket.clone()).await?;
+    doc_c
+        .set_download_policy(DownloadPolicy::NothingExcept(vec![]))
+        .await?;
+    let mut events_c = doc_c.subscribe().await?;
+    doc_c.start_sync(vec![addr_a.clone()]).await?;
+
+    assert_next_unordered_with_optionals(
+        &mut events_c,
+        TIMEOUT,
+        vec![
+            match_event!(LiveEvent::InsertRemote { .. }),
+            match_event!(LiveEvent::SyncFinished(_)),
+        ],
+        vec![
+            match_event!(LiveEvent::NeighborUp(_)),
+            match_event!(LiveEvent::PendingContentReady),
+        ],
+    )
+    .await;
+
+    // B joins and syncs with A (who has the blob)
+    info!("B: import and sync with A");
+    let doc_b = clients[1].docs().import(ticket.clone()).await?;
+    let blobs_b = clients[1].blobs();
+    let mut events_b = doc_b.subscribe().await?;
+    doc_b.start_sync(vec![addr_a]).await?;
+
+    assert_next_unordered_with_optionals(
+        &mut events_b,
+        TIMEOUT,
+        vec![
+            match_event!(LiveEvent::InsertRemote { .. }),
+            Box::new(move |e| matches!(e, LiveEvent::ContentReady { hash: h } if *h == hash)),
+            match_event!(LiveEvent::SyncFinished(_)),
+        ],
+        vec![
+            match_event!(LiveEvent::NeighborUp(_)),
+            match_event!(LiveEvent::NeighborUp(_)),
+            match_event!(LiveEvent::SyncFinished(_)),
+            match_event!(LiveEvent::SyncFinished(_)),
+            match_event!(LiveEvent::PendingContentReady),
+            match_event!(LiveEvent::PendingContentReady),
+            match_event!(LiveEvent::PendingContentReady),
+        ],
+    )
+    .await;
+
+    assert_latest(blobs_b, &doc_b, b"data", b"hello").await;
+
+    // C changes policy to download everything and syncs with B (who now has the blob)
+    info!("C: change policy and sync with B");
+    doc_c
+        .set_download_policy(DownloadPolicy::EverythingExcept(vec![]))
+        .await?;
+    let blobs_c = clients[2].blobs();
+    doc_c
+        .start_sync(vec![iroh::EndpointAddr::new(nodes[1].id())])
+        .await?;
+
+    assert_next_unordered_with_optionals(
+        &mut events_c,
+        TIMEOUT,
+        vec![Box::new(
+            move |e| matches!(e, LiveEvent::ContentReady { hash: h } if *h == hash),
+        )],
+        vec![
+            match_event!(LiveEvent::NeighborUp(_)),
+            match_event!(LiveEvent::NeighborUp(_)),
+            match_event!(LiveEvent::SyncFinished(_)),
+            match_event!(LiveEvent::SyncFinished(_)),
+            match_event!(LiveEvent::SyncFinished(_)),
+            match_event!(LiveEvent::PendingContentReady),
+            match_event!(LiveEvent::PendingContentReady),
+            match_event!(LiveEvent::PendingContentReady),
+        ],
+    )
+    .await;
+
+    assert_latest(blobs_c, &doc_c, b"data", b"hello").await;
+
+    for node in nodes {
+        node.shutdown().await?;
+    }
+    Ok(())
+}
+
+/// After a restart, blobs whose metadata was persisted but whose content was never
+/// downloaded should be fetched when the node syncs again.
+#[tokio::test]
+#[traced_test]
+#[cfg(feature = "fs-store")]
+async fn sync_retries_blob_after_restart() -> Result<()> {
+    use crate::util::endpoint;
+
+    let mut rng = test_rng(b"sync_retries_blob_after_restart");
+    let (relay_map, _relay_url, _guard) = iroh::test_utils::run_relay_server().await?;
+    let lookup_server = iroh::test_utils::DnsPkarrServer::run().await?;
+
+    // create node A with a doc and a blob
+    let secret_key_a = SecretKey::generate(&mut rng);
+    let ep_a = endpoint(secret_key_a, relay_map.clone(), Some(&lookup_server)).await?;
+    let node_a = Node::memory(ep_a).spawn().await?;
+    let author_a = node_a.docs().author_create().await?;
+    let doc_a = node_a.docs().create().await?;
+    let hash = doc_a
+        .set_bytes(author_a, b"restart_key".to_vec(), b"restart_value".to_vec())
+        .await?;
+    let ticket = doc_a
+        .share(ShareMode::Write, AddrInfoOptions::RelayAndAddresses)
+        .await?;
+
+    // create node B with persistent storage, join with NothingExcept policy
+    let node_b_dir = tempfile::TempDir::with_prefix("test-sync_retries_blob_after_restart-node_b")?;
+    let secret_key_b = SecretKey::generate(&mut rng);
+    let ep_b = endpoint(
+        secret_key_b.clone(),
+        relay_map.clone(),
+        Some(&lookup_server),
+    )
+    .await?;
+    let node_b = Node::persistent(&node_b_dir, ep_b).spawn().await?;
+    let id_b = node_b.id();
+
+    let doc_b = node_b.docs().import(ticket.clone()).await?;
+    doc_b
+        .set_download_policy(DownloadPolicy::NothingExcept(vec![]))
+        .await?;
+
+    let mut events_b = doc_b.subscribe().await?;
+
+    // wait for B's initial sync with A — metadata only, no blob
+    assert_next_unordered_with_optionals(
+        &mut events_b,
+        TIMEOUT,
+        vec![
+            match_event!(LiveEvent::InsertRemote { .. }),
+            match_event!(LiveEvent::SyncFinished(_)),
+        ],
+        vec![
+            match_event!(LiveEvent::NeighborUp(_)),
+            match_event!(LiveEvent::PendingContentReady),
+            match_event!(LiveEvent::SyncFinished(_)),
+            match_event!(LiveEvent::PendingContentReady),
+        ],
+    )
+    .await;
+
+    assert!(node_b.blobs().get_bytes(hash).await.is_err());
+
+    // change policy to download everything, then restart B
+    doc_b
+        .set_download_policy(DownloadPolicy::EverythingExcept(vec![]))
+        .await?;
+    let ns_b = doc_b.id();
+
+    info!(me = %id_b.fmt_short(), "node_b shutdown");
+    node_b.shutdown().await?;
+
+    info!(me = %id_b.fmt_short(), "node_b respawn");
+    let ep_b = endpoint(
+        secret_key_b.clone(),
+        relay_map.clone(),
+        Some(&lookup_server),
+    )
+    .await?;
+    let node_b = Node::persistent(&node_b_dir, ep_b).spawn().await?;
+    assert_eq!(id_b, node_b.id());
+
+    let doc_b = node_b.docs().open(ns_b).await?.expect("doc to exist");
+    let blobs_b = node_b.blobs();
+    let mut events_b = doc_b.subscribe().await?;
+
+    // trigger sync — the post-sync incomplete blob check should download the blob
+    info!(me = %id_b.fmt_short(), "node_b start_sync");
+    doc_b.start_sync(vec![]).await?;
+
+    assert_next_unordered_with_optionals(
+        &mut events_b,
+        TIMEOUT,
+        vec![Box::new(
+            move |e| matches!(e, LiveEvent::ContentReady { hash: h } if *h == hash),
+        )],
+        vec![
+            match_event!(LiveEvent::NeighborUp(_)),
+            match_event!(LiveEvent::SyncFinished(_)),
+            match_event!(LiveEvent::PendingContentReady),
+            match_event!(LiveEvent::SyncFinished(_)),
+            match_event!(LiveEvent::PendingContentReady),
+        ],
+    )
+    .await;
+
+    assert_latest(blobs_b, &doc_b, b"restart_key", b"restart_value").await;
+
+    node_a.shutdown().await?;
+    node_b.shutdown().await?;
+    Ok(())
+}
+
 async fn assert_latest(blobs: &iroh_blobs::api::Store, doc: &Doc, key: &[u8], value: &[u8]) {
     let content = get_latest(blobs, doc, key).await.unwrap();
     assert_eq!(content, value.to_vec());

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -1225,6 +1225,432 @@ async fn sync_drop_doc() -> Result<()> {
     Ok(())
 }
 
+/// Peer B first syncs with peer C (who has metadata but no blob), then syncs with peer A
+/// (who has the blob). Without the incomplete-blob retry after sync, B would never download.
+#[tokio::test]
+#[traced_test]
+async fn sync_retries_blob_from_second_peer() -> Result<()> {
+    let mut rng = test_rng(b"sync_retries_blob_from_second_peer");
+    let nodes = spawn_nodes(3, &mut rng).await?;
+    let clients = nodes.iter().map(|node| node.client()).collect::<Vec<_>>();
+
+    // A creates a doc and writes a key
+    let author_a = clients[0].docs().author_create().await?;
+    let doc_a = clients[0].docs().create().await?;
+    let hash = doc_a
+        .set_bytes(author_a, b"key1".to_vec(), b"value1".to_vec())
+        .await?;
+
+    let mut ticket = doc_a
+        .share(ShareMode::Write, AddrInfoOptions::RelayAndAddresses)
+        .await?;
+    let addr_a = ticket.nodes[0].clone();
+    // unset peers to not yet start sync
+    ticket.nodes = vec![];
+
+    // C joins with NothingExcept policy, syncs with A (metadata only, no blob)
+    info!("C: import and sync with A");
+    let doc_c = clients[2].docs().import(ticket.clone()).await?;
+    doc_c
+        .set_download_policy(DownloadPolicy::NothingExcept(vec![]))
+        .await?;
+    let mut events_c = doc_c.subscribe().await?;
+    doc_c.start_sync(vec![addr_a.clone()]).await?;
+    assert_next_unordered_with_optionals(
+        &mut events_c,
+        TIMEOUT,
+        vec![
+            match_event!(LiveEvent::InsertRemote { .. }),
+            match_event!(LiveEvent::SyncFinished(_)),
+        ],
+        vec![
+            match_event!(LiveEvent::NeighborUp(_)),
+            match_event!(LiveEvent::PendingContentReady),
+        ],
+    )
+    .await;
+
+    // B joins and syncs with C only — gets entry metadata but C has no blob to offer
+    info!("B: import and sync with C");
+    let ticket_c = doc_c
+        .share(ShareMode::Write, AddrInfoOptions::RelayAndAddresses)
+        .await?;
+    let addr_c = ticket_c.nodes[0].clone();
+
+    let doc_b = clients[1].docs().import(ticket.clone()).await?;
+    let blobs_b = clients[1].blobs();
+    let mut events_b = doc_b.subscribe().await?;
+
+    doc_b.start_sync(vec![addr_c]).await?;
+    assert_next_unordered_with_optionals(
+        &mut events_b,
+        TIMEOUT,
+        vec![
+            match_event!(LiveEvent::InsertRemote { .. }),
+            match_event!(LiveEvent::SyncFinished(_)),
+        ],
+        vec![
+            match_event!(LiveEvent::NeighborUp(_)),
+            match_event!(LiveEvent::NeighborUp(_)),
+            match_event!(LiveEvent::SyncFinished(_)),
+            match_event!(LiveEvent::PendingContentReady),
+            match_event!(LiveEvent::PendingContentReady),
+        ],
+    )
+    .await;
+
+    // B has the entry but not the blob
+    assert!(blobs_b.get_bytes(hash).await.is_err());
+
+    // B syncs with A — the post-sync incomplete blob check should discover and download it
+    info!("B: sync with A");
+    doc_b.start_sync(vec![addr_a]).await?;
+
+    assert_next_unordered_with_optionals(
+        &mut events_b,
+        TIMEOUT,
+        vec![Box::new(
+            move |e| matches!(e, LiveEvent::ContentReady { hash: h } if *h == hash),
+        )],
+        vec![
+            match_event!(LiveEvent::NeighborUp(_)),
+            match_event!(LiveEvent::NeighborUp(_)),
+            match_event!(LiveEvent::SyncFinished(_)),
+            match_event!(LiveEvent::SyncFinished(_)),
+            match_event!(LiveEvent::SyncFinished(_)),
+            match_event!(LiveEvent::PendingContentReady),
+            match_event!(LiveEvent::PendingContentReady),
+            match_event!(LiveEvent::PendingContentReady),
+        ],
+    )
+    .await;
+
+    assert_latest(blobs_b, &doc_b, b"key1", b"value1").await;
+
+    for node in nodes {
+        node.shutdown().await?;
+    }
+    Ok(())
+}
+
+/// After changing the download policy to include previously excluded keys, a re-sync should
+/// trigger downloads for those entries.
+#[tokio::test]
+#[traced_test]
+async fn sync_retries_blob_after_policy_change() -> Result<()> {
+    let mut rng = test_rng(b"sync_retries_blob_after_policy_change");
+    let nodes = spawn_nodes(2, &mut rng).await?;
+    let clients = nodes.iter().map(|node| node.client()).collect::<Vec<_>>();
+
+    // A writes two keys
+    let author_a = clients[0].docs().author_create().await?;
+    let doc_a = clients[0].docs().create().await?;
+    let hash_inc = doc_a
+        .set_bytes(author_a, b"included".to_vec(), b"yes".to_vec())
+        .await?;
+    let hash_exc = doc_a
+        .set_bytes(author_a, b"excluded".to_vec(), b"no".to_vec())
+        .await?;
+
+    let mut ticket = doc_a
+        .share(ShareMode::Write, AddrInfoOptions::RelayAndAddresses)
+        .await?;
+    let addr_a = ticket.nodes[0].clone();
+    // unset peers to not yet start sync
+    ticket.nodes = vec![];
+
+    // B joins with NothingExcept("included"), syncs with A
+    info!("B: import and sync with policy NothingExcept(included)");
+    let doc_b = clients[1].docs().import(ticket).await?;
+    let blobs_b = clients[1].blobs();
+    doc_b
+        .set_download_policy(DownloadPolicy::NothingExcept(vec![FilterKind::Exact(
+            "included".into(),
+        )]))
+        .await?;
+    let mut events_b = doc_b.subscribe().await?;
+
+    doc_b.start_sync(vec![addr_a.clone()]).await?;
+
+    // B gets both entries but only downloads "included"
+    assert_next_unordered_with_optionals(
+        &mut events_b,
+        TIMEOUT,
+        vec![
+            match_event!(LiveEvent::InsertRemote { .. }),
+            match_event!(LiveEvent::InsertRemote { .. }),
+            Box::new(move |e| matches!(e, LiveEvent::ContentReady { hash } if *hash == hash_inc)),
+        ],
+        vec![
+            match_event!(LiveEvent::NeighborUp(_)),
+            match_event!(LiveEvent::SyncFinished(_)),
+            match_event!(LiveEvent::SyncFinished(_)),
+            match_event!(LiveEvent::PendingContentReady),
+            match_event!(LiveEvent::PendingContentReady),
+        ],
+    )
+    .await;
+
+    assert_latest(blobs_b, &doc_b, b"included", b"yes").await;
+    assert!(blobs_b.get_bytes(hash_exc).await.is_err());
+
+    // B changes policy to download everything and re-syncs
+    info!("B: change policy to EverythingExcept and re-sync");
+    doc_b
+        .set_download_policy(DownloadPolicy::EverythingExcept(vec![]))
+        .await?;
+    doc_b.start_sync(vec![addr_a]).await?;
+
+    // the post-sync incomplete blob check should now download the previously excluded blob
+    assert_next_unordered_with_optionals(
+        &mut events_b,
+        TIMEOUT,
+        vec![Box::new(
+            move |e| matches!(e, LiveEvent::ContentReady { hash } if *hash == hash_exc),
+        )],
+        vec![
+            match_event!(LiveEvent::NeighborUp(_)),
+            match_event!(LiveEvent::SyncFinished(_)),
+            match_event!(LiveEvent::SyncFinished(_)),
+            match_event!(LiveEvent::PendingContentReady),
+            match_event!(LiveEvent::PendingContentReady),
+        ],
+    )
+    .await;
+
+    assert_latest(blobs_b, &doc_b, b"excluded", b"no").await;
+
+    for node in nodes {
+        node.shutdown().await?;
+    }
+    Ok(())
+}
+
+/// When B downloads a previously missing blob after syncing with A, C (also missing the blob)
+/// can fetch it from B by syncing with B.
+#[tokio::test]
+#[traced_test]
+async fn sync_retries_missing_blob_propagates_content_ready() -> Result<()> {
+    let mut rng = test_rng(b"sync_retries_propagation");
+    let nodes = spawn_nodes(3, &mut rng).await?;
+    let clients = nodes.iter().map(|node| node.client()).collect::<Vec<_>>();
+
+    // A creates a doc and writes a key
+    let author_a = clients[0].docs().author_create().await?;
+    let doc_a = clients[0].docs().create().await?;
+    let hash = doc_a
+        .set_bytes(author_a, b"data".to_vec(), b"hello".to_vec())
+        .await?;
+
+    let mut ticket = doc_a
+        .share(ShareMode::Write, AddrInfoOptions::RelayAndAddresses)
+        .await?;
+    let addr_a = ticket.nodes[0].clone();
+    // unset peers to not yet start sync
+    ticket.nodes = vec![];
+
+    // C joins with NothingExcept policy, syncs with A (metadata only, no blob)
+    info!("C: import and sync with A");
+    let doc_c = clients[2].docs().import(ticket.clone()).await?;
+    doc_c
+        .set_download_policy(DownloadPolicy::NothingExcept(vec![]))
+        .await?;
+    let mut events_c = doc_c.subscribe().await?;
+    doc_c.start_sync(vec![addr_a.clone()]).await?;
+
+    assert_next_unordered_with_optionals(
+        &mut events_c,
+        TIMEOUT,
+        vec![
+            match_event!(LiveEvent::InsertRemote { .. }),
+            match_event!(LiveEvent::SyncFinished(_)),
+        ],
+        vec![
+            match_event!(LiveEvent::NeighborUp(_)),
+            match_event!(LiveEvent::PendingContentReady),
+        ],
+    )
+    .await;
+
+    // B joins and syncs with A (who has the blob)
+    info!("B: import and sync with A");
+    let doc_b = clients[1].docs().import(ticket.clone()).await?;
+    let blobs_b = clients[1].blobs();
+    let mut events_b = doc_b.subscribe().await?;
+    doc_b.start_sync(vec![addr_a]).await?;
+
+    assert_next_unordered_with_optionals(
+        &mut events_b,
+        TIMEOUT,
+        vec![
+            match_event!(LiveEvent::InsertRemote { .. }),
+            Box::new(move |e| matches!(e, LiveEvent::ContentReady { hash: h } if *h == hash)),
+            match_event!(LiveEvent::SyncFinished(_)),
+        ],
+        vec![
+            match_event!(LiveEvent::NeighborUp(_)),
+            match_event!(LiveEvent::NeighborUp(_)),
+            match_event!(LiveEvent::SyncFinished(_)),
+            match_event!(LiveEvent::SyncFinished(_)),
+            match_event!(LiveEvent::PendingContentReady),
+            match_event!(LiveEvent::PendingContentReady),
+            match_event!(LiveEvent::PendingContentReady),
+        ],
+    )
+    .await;
+
+    assert_latest(blobs_b, &doc_b, b"data", b"hello").await;
+
+    // C changes policy to download everything and syncs with B (who now has the blob)
+    info!("C: change policy and sync with B");
+    doc_c
+        .set_download_policy(DownloadPolicy::EverythingExcept(vec![]))
+        .await?;
+    let blobs_c = clients[2].blobs();
+    doc_c
+        .start_sync(vec![iroh::EndpointAddr::new(nodes[1].id())])
+        .await?;
+
+    assert_next_unordered_with_optionals(
+        &mut events_c,
+        TIMEOUT,
+        vec![Box::new(
+            move |e| matches!(e, LiveEvent::ContentReady { hash: h } if *h == hash),
+        )],
+        vec![
+            match_event!(LiveEvent::NeighborUp(_)),
+            match_event!(LiveEvent::NeighborUp(_)),
+            match_event!(LiveEvent::SyncFinished(_)),
+            match_event!(LiveEvent::SyncFinished(_)),
+            match_event!(LiveEvent::SyncFinished(_)),
+            match_event!(LiveEvent::PendingContentReady),
+            match_event!(LiveEvent::PendingContentReady),
+            match_event!(LiveEvent::PendingContentReady),
+        ],
+    )
+    .await;
+
+    assert_latest(blobs_c, &doc_c, b"data", b"hello").await;
+
+    for node in nodes {
+        node.shutdown().await?;
+    }
+    Ok(())
+}
+
+/// After a restart, blobs whose metadata was persisted but whose content was never
+/// downloaded should be fetched when the node syncs again.
+#[tokio::test]
+#[traced_test]
+#[cfg(feature = "fs-store")]
+async fn sync_retries_blob_after_restart() -> Result<()> {
+    use crate::util::endpoint;
+
+    let _rng = test_rng(b"sync_retries_blob_after_restart");
+    let (relay_map, _relay_url, _guard) = iroh::test_utils::run_relay_server().await?;
+    let lookup_server = iroh::test_utils::DnsPkarrServer::run().await?;
+
+    // create node A with a doc and a blob
+    let secret_key_a = SecretKey::generate();
+    let ep_a = endpoint(secret_key_a, relay_map.clone(), Some(&lookup_server)).await?;
+    let node_a = Node::memory(ep_a).spawn().await?;
+    let author_a = node_a.docs().author_create().await?;
+    let doc_a = node_a.docs().create().await?;
+    let hash = doc_a
+        .set_bytes(author_a, b"restart_key".to_vec(), b"restart_value".to_vec())
+        .await?;
+    let ticket = doc_a
+        .share(ShareMode::Write, AddrInfoOptions::RelayAndAddresses)
+        .await?;
+
+    // create node B with persistent storage, join with NothingExcept policy
+    let node_b_dir = tempfile::TempDir::with_prefix("test-sync_retries_blob_after_restart-node_b")?;
+    let secret_key_b = SecretKey::generate();
+    let ep_b = endpoint(
+        secret_key_b.clone(),
+        relay_map.clone(),
+        Some(&lookup_server),
+    )
+    .await?;
+    let node_b = Node::persistent(&node_b_dir, ep_b).spawn().await?;
+    let id_b = node_b.id();
+
+    let doc_b = node_b.docs().import(ticket.clone()).await?;
+    doc_b
+        .set_download_policy(DownloadPolicy::NothingExcept(vec![]))
+        .await?;
+
+    let mut events_b = doc_b.subscribe().await?;
+
+    // wait for B's initial sync with A — metadata only, no blob
+    assert_next_unordered_with_optionals(
+        &mut events_b,
+        TIMEOUT,
+        vec![
+            match_event!(LiveEvent::InsertRemote { .. }),
+            match_event!(LiveEvent::SyncFinished(_)),
+        ],
+        vec![
+            match_event!(LiveEvent::NeighborUp(_)),
+            match_event!(LiveEvent::PendingContentReady),
+            match_event!(LiveEvent::SyncFinished(_)),
+            match_event!(LiveEvent::PendingContentReady),
+        ],
+    )
+    .await;
+
+    assert!(node_b.blobs().get_bytes(hash).await.is_err());
+
+    // change policy to download everything, then restart B
+    doc_b
+        .set_download_policy(DownloadPolicy::EverythingExcept(vec![]))
+        .await?;
+    let ns_b = doc_b.id();
+
+    info!(me = %id_b.fmt_short(), "node_b shutdown");
+    node_b.shutdown().await?;
+
+    info!(me = %id_b.fmt_short(), "node_b respawn");
+    let ep_b = endpoint(
+        secret_key_b.clone(),
+        relay_map.clone(),
+        Some(&lookup_server),
+    )
+    .await?;
+    let node_b = Node::persistent(&node_b_dir, ep_b).spawn().await?;
+    assert_eq!(id_b, node_b.id());
+
+    let doc_b = node_b.docs().open(ns_b).await?.expect("doc to exist");
+    let blobs_b = node_b.blobs();
+    let mut events_b = doc_b.subscribe().await?;
+
+    // trigger sync — the post-sync incomplete blob check should download the blob
+    info!(me = %id_b.fmt_short(), "node_b start_sync");
+    doc_b.start_sync(vec![]).await?;
+
+    assert_next_unordered_with_optionals(
+        &mut events_b,
+        TIMEOUT,
+        vec![Box::new(
+            move |e| matches!(e, LiveEvent::ContentReady { hash: h } if *h == hash),
+        )],
+        vec![
+            match_event!(LiveEvent::NeighborUp(_)),
+            match_event!(LiveEvent::SyncFinished(_)),
+            match_event!(LiveEvent::PendingContentReady),
+            match_event!(LiveEvent::SyncFinished(_)),
+            match_event!(LiveEvent::PendingContentReady),
+        ],
+    )
+    .await;
+
+    assert_latest(blobs_b, &doc_b, b"restart_key", b"restart_value").await;
+
+    node_a.shutdown().await?;
+    node_b.shutdown().await?;
+    Ok(())
+}
+
 async fn assert_latest(blobs: &iroh_blobs::api::Store, doc: &Doc, key: &[u8], value: &[u8]) {
     let content = get_latest(blobs, doc, key).await.unwrap();
     assert_eq!(content, value.to_vec());

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -100,6 +100,8 @@ impl Builder {
         if let Some(protect_cb) = protect_cb {
             docs_builder = docs_builder.protect_handler(protect_cb);
         }
+        // Scan on every sync in tests (deterministic); production debounces.
+        docs_builder = docs_builder.incomplete_blob_check_interval(std::time::Duration::ZERO);
         let docs = match docs_builder
             .spawn(self.endpoint.clone(), blobs.clone(), gossip.clone())
             .await


### PR DESCRIPTION
## Description

After a successful sync, blob downloads could silently fail to retry in several scenarios:

1. **Peer lacked the content**: A sync provides entry metadata but the remote peer doesn't have the blob data. The hash is added to the in-memory `missing_hashes` set, but no `RemoteInsert` event fires on subsequent syncs with other peers who *do* have the blob.
2. **Restart loses state**: The `missing_hashes` set is in-memory only. After a node restart, hashes that were pending download are forgotten and never retried.
3. **Download policy change**: A node that initially excluded certain keys via `DownloadPolicy` would never download their blobs after switching to a more permissive policy, because no new `RemoteInsert` is emitted for entries already in the store.
4. **Download failure from flaky peer**: A peer with poor connectivity writes a key. Other peers receive the entry metadata via gossip and attempt to download the blob, but the transfer fails due to the flaky connection. The hash ends up in `missing_hashes`, but nothing triggers a retry — no new `RemoteInsert` fires (the entry is already known), and no `ContentReady` is broadcast (no one else has the blob). The download is effectively stuck until either the flaky peer comes back and a new sync happens, or someone else acquires and advertises the blob.

This PR adds `check_incomplete_blobs`, called at the end of every successful sync. It scans the namespace for entries whose blobs are not yet complete (respecting the current download policy) and queues them for download with the sync peer as a candidate provider. Since `start_download` already short-circuits for complete blobs and deduplicates via `queued_hashes`, this is safe to call unconditionally.

Four integration tests cover the fix:

- `sync_retries_blob_from_second_peer` — B syncs with C (metadata only), then A (has blob)
- `sync_retries_blob_after_policy_change` — B excludes a key, changes policy, re-syncs
- `sync_retries_missing_blob_propagates_content_ready` — blob propagates from A → B → C
- `sync_retries_blob_after_restart` — persistent node restarts and re-downloads

Scenario 4 (download failure from a flaky peer) is not directly tested because reliably simulating a transport-level download failure in an integration test would require either mocking the downloader or precise timing control over a node going offline mid-transfer — neither is practical with the current test infrastructure. However, the code path is the same: regardless of *why* a blob is incomplete (policy, missing remote content, failed download, or lost state), `check_incomplete_blobs` finds it by checking the blob store directly and queues a fresh download.

Closes #82

/cc @gusinacio @rustonbsd

## Breaking Changes

None.

## Notes & open questions

- `check_incomplete_blobs` queries all entries in the namespace on every sync. For documents with a very large number of entries this adds overhead, though `start_download` returns immediately for already-complete blobs. A future optimization could track incomplete hashes more precisely to avoid the full scan.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
