### PR TITLE
fix: improve lock safety and document unsafe channel comparison

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+docs/aster/

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -454,7 +454,10 @@ impl DefaultAuthor {
 
     /// Get the current default author.
     pub fn get(&self) -> AuthorId {
-        *self.value.read().unwrap()
+        *self
+            .value
+            .read()
+            .expect("DefaultAuthor lock poisoned in get()")
     }
 
     /// Set the default author.
@@ -463,7 +466,10 @@ impl DefaultAuthor {
             bail!("The author does not exist");
         }
         self.storage.persist(author_id).await?;
-        *self.value.write().unwrap() = author_id;
+        *self
+            .value
+            .write()
+            .expect("DefaultAuthor lock poisoned in set()") = author_id;
         Ok(())
     }
 }

--- a/src/engine/live.rs
+++ b/src/engine/live.rs
@@ -757,7 +757,7 @@ impl LiveActor {
         self.hash_providers
             .0
             .lock()
-            .expect("poisoned")
+            .expect("ProviderNodes lock poisoned in start_download()")
             .entry(hash)
             .or_default()
             .insert(node);
@@ -904,7 +904,7 @@ impl ContentDiscovery for ProviderNodes {
         let nodes = self
             .0
             .lock()
-            .expect("poisoned")
+            .expect("ProviderNodes lock poisoned in find_providers()")
             .get(&hash.hash)
             .into_iter()
             .flatten()

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -107,20 +107,35 @@ pub struct SyncOutcome {
     pub num_sent: usize,
 }
 
-fn get_as_ptr<T>(value: &T) -> Option<usize> {
-    use std::mem;
-    if mem::size_of::<T>() == std::mem::size_of::<usize>()
-        && mem::align_of::<T>() == mem::align_of::<usize>()
-    {
-        // Safe only if size and alignment requirements are met
-        unsafe { Some(mem::transmute_copy(value)) }
-    } else {
-        None
-    }
-}
-
+/// Compare two `async_channel::Sender`s for channel identity.
+///
+/// `async_channel::Sender<T>` wraps a single `Arc<Channel<T>>` field.
+/// We extract the Arc's pointer value via `transmute_copy` to compare
+/// identity. The size/alignment checks ensure this is valid for the
+/// specific `async_channel` version in use.
+///
+/// # Safety
+/// This relies on `Sender<T>` being layout-compatible with a single pointer,
+/// which is verified at runtime via size and alignment checks. If the check
+/// fails, we fall back to returning `false` (never matching), which is safe
+/// but may leave stale entries that get cleaned up on next send.
 fn same_channel<T>(a: &async_channel::Sender<T>, b: &async_channel::Sender<T>) -> bool {
-    get_as_ptr(a).unwrap() == get_as_ptr(b).unwrap()
+    use std::mem;
+    if mem::size_of::<async_channel::Sender<T>>() == mem::size_of::<usize>()
+        && mem::align_of::<async_channel::Sender<T>>() == mem::align_of::<usize>()
+    {
+        // SAFETY: We verified that Sender<T> has the same size and alignment as
+        // a pointer. Sender<T> contains a single Arc<Channel<T>> field, so
+        // transmute_copy extracts the Arc's raw pointer value for comparison.
+        let ptr_a: usize = unsafe { mem::transmute_copy(a) };
+        let ptr_b: usize = unsafe { mem::transmute_copy(b) };
+        ptr_a == ptr_b
+    } else {
+        // Layout doesn't match our assumption — fall back to never matching.
+        // Stale senders will be cleaned up when their receiver is dropped and
+        // the next `send()` call fails.
+        false
+    }
 }
 
 #[derive(Debug, Default)]


### PR DESCRIPTION
## Summary
- Document the safety invariants for the `same_channel` comparison in Subscribers, which uses `transmute_copy` to extract Arc pointer values from `async_channel::Sender`
- Add a fallback that returns false if the layout assumption fails, instead of panicking via `.unwrap()`
- Add descriptive messages to `.expect()` calls on RwLock/Mutex operations in DefaultAuthor and ProviderNodes

## Test plan
- [x] All tests pass
- [x] `cargo make format-check` passes
- [x] `cargo clippy -- -D warnings` passes