### PR TITLE
fix: reduce MAX_MESSAGE_SIZE and handle premature import stream end

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -648,7 +648,13 @@ impl Stream for ImportFileProgress {
                         }
                         item => Poll::Ready(Some(ImportFileProgressItem::Blobs(item))),
                     },
-                    None => todo!(),
+                    None => {
+                        // Blob import stream ended without emitting Done.
+                        *this = Self(ImportInner::Done);
+                        Poll::Ready(Some(ImportFileProgressItem::Error(anyhow::anyhow!(
+                            "blob import stream ended prematurely"
+                        ))))
+                    }
                 }
             }
             ImportInner::Entry(ref mut fut) => {

--- a/src/net/codec.rs
+++ b/src/net/codec.rs
@@ -19,7 +19,12 @@ use crate::{
 #[derive(Debug, Default)]
 struct SyncCodec;
 
-const MAX_MESSAGE_SIZE: usize = 1024 * 1024 * 1024; // This is likely too large, but lets have some restrictions
+/// Maximum sync message size: 64 MiB.
+///
+/// Reduced from the original 1 GiB to prevent trivial memory exhaustion attacks
+/// where a malicious peer sends oversized messages. 64 MiB is generous for
+/// range-based set reconciliation messages.
+const MAX_MESSAGE_SIZE: usize = 64 * 1024 * 1024;
 
 impl Decoder for SyncCodec {
     type Item = Message;


### PR DESCRIPTION
## Summary
- Reduce MAX_MESSAGE_SIZE from 1 GiB to 64 MiB — the original value allowed trivial memory exhaustion attacks where a malicious peer could force 1 GB allocations per message
- Replace `todo!()` panic in ImportFileProgress poll with proper error handling — if the blob import stream ends without emitting a Done event, the progress stream now emits an error instead of crashing

## Test plan
- [x] All tests pass
- [x] `cargo make format-check` passes
- [x] `cargo clippy -- -D warnings` passes