### PR TITLE
fix: bound public key cache and entry key size

### DIFF
--- a/src/store/pubkeys.rs
+++ b/src/store/pubkeys.rs
@@ -51,8 +51,12 @@ impl PublicKeyStore for () {
     }
 }
 
-/// In-memory key storage
-// TODO: Make max number of keys stored configurable.
+/// Maximum number of cached public keys.
+///
+/// Limits memory growth from entries with many distinct author/namespace IDs.
+const MAX_CACHED_KEYS: usize = 10_000;
+
+/// In-memory key storage with bounded cache.
 #[derive(Debug, Clone, Default)]
 pub struct MemPublicKeyStore {
     keys: Arc<RwLock<HashMap<[u8; 32], VerifyingKey>>>,
@@ -60,11 +64,25 @@ pub struct MemPublicKeyStore {
 
 impl PublicKeyStore for MemPublicKeyStore {
     fn public_key(&self, bytes: &[u8; 32]) -> Result<VerifyingKey, SignatureError> {
-        if let Some(id) = self.keys.read().unwrap().get(bytes) {
+        if let Some(id) = self
+            .keys
+            .read()
+            .expect("MemPublicKeyStore read lock poisoned")
+            .get(bytes)
+        {
             return Ok(*id);
         }
         let id = VerifyingKey::from_bytes(bytes)?;
-        self.keys.write().unwrap().insert(*bytes, id);
+        let mut guard = self
+            .keys
+            .write()
+            .expect("MemPublicKeyStore write lock poisoned");
+        // Evict the entire cache if it exceeds the limit. A simple strategy
+        // that avoids the complexity of LRU while bounding memory usage.
+        if guard.len() >= MAX_CACHED_KEYS {
+            guard.clear();
+        }
+        guard.insert(*bytes, id);
         Ok(id)
     }
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1013,13 +1013,29 @@ fn system_time_now() -> u64 {
         .as_micros() as u64
 }
 
+/// Maximum key size for a record identifier (4 KiB).
+///
+/// Prevents unbounded memory allocation from entries with arbitrarily large keys,
+/// whether from local misuse or malicious peers during sync.
+pub const MAX_KEY_SIZE: usize = 4096;
+
 impl RecordIdentifier {
     /// Create a new [`RecordIdentifier`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `key` exceeds [`MAX_KEY_SIZE`] bytes.
     pub fn new(
         namespace: impl Into<NamespaceId>,
         author: impl Into<AuthorId>,
         key: impl AsRef<[u8]>,
     ) -> Self {
+        assert!(
+            key.as_ref().len() <= MAX_KEY_SIZE,
+            "key size {} exceeds maximum of {} bytes",
+            key.as_ref().len(),
+            MAX_KEY_SIZE,
+        );
         let mut bytes = BytesMut::with_capacity(32 + 32 + key.as_ref().len());
         bytes.extend_from_slice(namespace.into().as_bytes());
         bytes.extend_from_slice(author.into().as_bytes());


### PR DESCRIPTION
## Summary
- MemPublicKeyStore now evicts the entire cache when it exceeds 10,000 entries, preventing unbounded memory growth from entries with many distinct author/namespace IDs
- RecordIdentifier::new() now panics if the key exceeds 4 KiB, preventing unbounded memory allocation from entries with arbitrarily large keys

## Test plan
- [x] All tests pass
- [x] `cargo make format-check` passes
- [x] `cargo clippy -- -D warnings` passes