### PR TITLE
fix: reduce clock skew tolerance and document migration bounds

### DIFF
--- a/src/store/fs/migrations.rs
+++ b/src/store/fs/migrations.rs
@@ -50,6 +50,8 @@ fn migration_001_populate_latest_table(tx: &WriteTransaction) -> Result<MigrateO
         return Ok(MigrateOutcome::Skip);
     }
 
+    // The HashMap is bounded by the number of distinct (namespace, author) pairs,
+    // not the total number of records, since we only keep the latest entry per author.
     #[allow(clippy::type_complexity)]
     let mut heads: HashMap<([u8; 32], [u8; 32]), (u64, Vec<u8>)> = HashMap::new();
     let iter = records_table.iter()?;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -39,8 +39,9 @@ pub type ProtocolMessage = crate::ranger::Message<SignedEntry>;
 pub type PeerIdBytes = [u8; 32];
 
 /// Max time in the future from our wall clock time that we accept entries for.
-/// Value is 10 minutes.
-pub const MAX_TIMESTAMP_FUTURE_SHIFT: u64 = 10 * 60 * Duration::from_secs(1).as_millis() as u64;
+/// Value is 5 minutes. Reduced from the original 10 minutes to limit the window
+/// for timestamp manipulation by malicious peers.
+pub const MAX_TIMESTAMP_FUTURE_SHIFT: u64 = 5 * 60 * Duration::from_secs(1).as_millis() as u64;
 
 /// Callback that may be set on a replica to determine the availability status for a content hash.
 pub type ContentStatusCallback =


### PR DESCRIPTION
## Summary
- Reduce MAX_TIMESTAMP_FUTURE_SHIFT from 10 minutes to 5 minutes, limiting the window for timestamp manipulation by malicious peers during sync
- Add documentation clarifying that the migration HashMap in migration_001 is bounded by distinct (namespace, author) pairs, not total records

## Test plan
- [x] All tests pass
- [x] `cargo make format-check` passes
- [x] `cargo clippy -- -D warnings` passes