### PR TITLE
fix(store): keep records-by-key index in sync on prefix delete

### DIFF
--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -881,8 +881,26 @@ impl<'a> crate::ranger::Store<SignedEntry> for StoreInstance<'a> {
 
                 predicate(&record)
             };
-            let iter = tables.records.extract_from_if(bounds.as_ref(), cb)?;
-            let count = iter.count();
+            // Collect the keys to remove first, draining the iterator (which performs the
+            // deletion from `records`) so the `tables.records` borrow is released before we
+            // touch `tables.records_by_key`.
+            let removed: Vec<([u8; 32], [u8; 32], Vec<u8>)> = tables
+                .records
+                .extract_from_if(bounds.as_ref(), cb)?
+                .map(|res| {
+                    res.map(|(k, _v)| {
+                        let (namespace, author, key) = k.value();
+                        (*namespace, *author, key.to_vec())
+                    })
+                })
+                .collect::<Result<_, _>>()?;
+            let count = removed.len();
+            // Keep the by-key index in sync: it is keyed `(namespace, key, author)`.
+            for (namespace, author, key) in &removed {
+                tables
+                    .records_by_key
+                    .remove((namespace, key.as_slice(), author))?;
+            }
             Ok(count)
         })
     }
@@ -1308,6 +1326,116 @@ mod tests {
 
         let _store = Store::persistent(&path)?;
         assert!(!backup.exists());
+        Ok(())
+    }
+
+    /// `remove_prefix_filtered` must keep the `records_by_key` index 1:1 with `records`,
+    /// removing the index rows for every record it deletes and leaving unrelated prefixes alone.
+    #[test]
+    fn test_remove_prefix_filtered_cleans_by_key_index() -> Result<()> {
+        use redb::ReadableTableMetadata;
+
+        let dbfile = tempfile::NamedTempFile::new()?;
+        let mut store = Store::persistent(dbfile.path())?;
+        let author = store.new_author(&mut rand::rng())?;
+        let namespace = NamespaceSecret::new(&mut rand::rng());
+        let _replica = store.new_replica(namespace.clone())?;
+        store.close_replica(namespace.id());
+
+        let mut wrapper = StoreInstance::new(namespace.id(), &mut store);
+        for i in 0..8 {
+            let id = RecordIdentifier::new(namespace.id(), author.id(), format!("events/{i}"));
+            let entry = Entry::new(id, Record::current_from_data(format!("v{i}")));
+            let entry = SignedEntry::from_entry(entry, &namespace, &author);
+            wrapper.entry_put(entry)?;
+        }
+        // An unrelated record under a different prefix that must survive the delete.
+        let id = RecordIdentifier::new(namespace.id(), author.id(), "config/x");
+        let entry = Entry::new(id, Record::current_from_data("keep"));
+        let entry = SignedEntry::from_entry(entry, &namespace, &author);
+        wrapper.entry_put(entry)?;
+
+        // Both tables must hold one row per record before we delete anything.
+        {
+            let tables = wrapper.store.tables()?;
+            assert_eq!(tables.records.len()?, 9);
+            assert_eq!(tables.records_by_key.len()?, 9);
+        }
+
+        // Delete the `events/` prefix through the production path.
+        let prefix = RecordIdentifier::new(namespace.id(), author.id(), "events/");
+        let removed = wrapper.remove_prefix_filtered(&prefix, |_| true)?;
+        assert_eq!(removed, 8);
+
+        let tables = wrapper.store.tables()?;
+        assert_eq!(
+            tables.records.len()?,
+            1,
+            "only the unrelated `config/x` record should remain",
+        );
+        assert_eq!(
+            tables.records_by_key.len()?,
+            tables.records.len()?,
+            "records_by_key index out of sync with records after remove_prefix_filtered",
+        );
+
+        Ok(())
+    }
+
+    /// `Replica::delete_prefix` must keep the `records_by_key` index 1:1 with `records`.
+    #[tokio::test]
+    async fn test_delete_prefix_keeps_by_key_index_in_sync() -> Result<()> {
+        use redb::ReadableTableMetadata;
+
+        let dbfile = tempfile::NamedTempFile::new()?;
+        let mut store = Store::persistent(dbfile.path())?;
+        let author = store.new_author(&mut rand::rng())?;
+        let namespace = NamespaceSecret::new(&mut rand::rng());
+
+        // Insert a batch of records under a common prefix plus one unrelated record.
+        let mut replica = store.new_replica(namespace.clone())?;
+        for i in 0..10 {
+            replica
+                .hash_and_insert(format!("events/{i}"), &author, format!("value-{i}"))
+                .await?;
+        }
+        replica
+            .hash_and_insert("config/keep", &author, b"keep")
+            .await?;
+        drop(replica);
+
+        // Sanity check: index and records are in sync before deleting (11 records).
+        {
+            let tables = store.tables()?;
+            assert_eq!(tables.records.len()?, 11);
+            assert_eq!(tables.records_by_key.len()?, 11);
+        }
+
+        // Bulk-delete the prefix. This routes through `remove_prefix_filtered`.
+        let mut replica = store.new_replica(namespace.clone())?;
+        let deleted = replica.delete_prefix("events/", &author).await?;
+        assert_eq!(deleted, 10, "all 10 prefixed records should be removed");
+        drop(replica);
+
+        // `records` now holds the surviving `config/keep` record plus the empty `events/` delete
+        // marker, and the index must match it exactly.
+        {
+            let tables = store.tables()?;
+            assert_eq!(
+                tables.records_by_key.len()?,
+                tables.records.len()?,
+                "records_by_key index out of sync with records after delete_prefix",
+            );
+            assert_eq!(tables.records.len()?, 2);
+        }
+
+        // The surviving record is still reachable; the empty delete marker is filtered out.
+        let keys: Vec<_> = store
+            .get_many(namespace.id(), Query::all())?
+            .map(|e| e.map(|e| e.key().to_vec()))
+            .collect::<Result<_>>()?;
+        assert_eq!(keys, vec![b"config/keep".to_vec()]);
+
         Ok(())
     }
 }


### PR DESCRIPTION
## Description

Fixes a secondary-index leak in the redb (`fs-store`) replica store.

The store keeps two tables that must stay 1:1:

| Table | Key | Role |
| ----- | --- | ---- |
| `records-1` | `(namespace, author, key)` | authoritative records |
| `records-by-key-1` | `(namespace, key, author)` | secondary index, value `()` |

`StoreInstance::remove_prefix_filtered` (`src/store/fs.rs`) is the production prefix-delete path. It is called from `Ranger::put` whenever an entry supersedes its prefix children, which is exactly what `Replica::delete_prefix` triggers. It removed rows from `records` only and never removed the matching rows from `records_by_key`. Every prefix-deleted record therefore leaked an orphan index row that was never reclaimed.

The only code that removed from both tables was `entry_remove`, which is `#[cfg(test)]` and never runs in production, so there was no live code path that kept the index in sync on delete.

Consequences:

- **Unbounded store growth**: orphan index rows in `records-by-key-1` are never reclaimed and accumulate on every delete-heavy namespace.
- **Degraded / incorrect key-range queries**: `RecordsByKeyRange` walks `records-by-key-1` and dereferences into `records-1`; orphans are dangling pointers that, at best, waste work and, at worst, surface as lookup misses.

### Changes

- `remove_prefix_filtered` now drains the `extract_from_if` iterator into the set of removed keys (which performs the deletion from `records`) and then removes the corresponding row from `records_by_key` for each one, keeping the index 1:1 with `records`. The collect-first step releases the mutable borrow of `tables.records` before `tables.records_by_key` is mutated.
- Added two regression tests asserting `records_by_key.len() == records.len()` after a delete:
  - `test_remove_prefix_filtered_cleans_by_key_index` exercises `remove_prefix_filtered` directly and confirms records under unrelated prefixes are untouched.
  - `test_delete_prefix_keeps_by_key_index_in_sync` drives the same path end-to-end through `Replica::delete_prefix`.

## Breaking Changes

None. This is a behavioural bug fix internal to the `fs-store` backend; no public API changes.

## Notes & open questions

- This fix prevents *new* orphans. It does not retroactively prune orphan rows that already accumulated in existing stores. Because `records-by-key-1` is a pure derived index, an existing store can be repaired offline (with the scheduler stopped) by clearing `records-by-key-1` and re-inserting `(namespace, key, author) -> ()` for every row in `records-1`. A migration could be added if we want this to self-heal on open; left out of this PR to keep it focused.
- `entry_remove` remains `#[cfg(test)]`. The single-entry remove is only used by tests, and the prefix path is the one that runs in production. Worth considering whether both deletes should route through one shared helper so the index-cleanup can't drift out of the live path again.
- Detection for the fleet: on any `docs.redb`, `count(records-by-key-1) > count(records-1)` means the leak is present and the delta is the orphan count.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
