### PR TITLE
feat(store): add key_prefix_from cursor to Query for efficient prefix scans

### DIFF
--- a/src/store.rs
+++ b/src/store.rs
@@ -193,7 +193,10 @@ impl<K> QueryBuilder<K> {
     /// Filter by key prefix, starting from a cursor position.
     ///
     /// Only keys at or after `from` will be returned. The seek is performed
-    /// at the B-tree level (O(log n)).
+    /// at the B-tree level (O(log n)). Requires `SortBy::KeyAuthor` ordering
+    /// to use the by-key index, otherwise `from` is ignored.
+    ///
+    /// The `from` value must start with the given prefix for correct results.
     pub fn key_prefix_from(
         mut self,
         prefix: impl AsRef<[u8]>,

--- a/src/store.rs
+++ b/src/store.rs
@@ -171,6 +171,7 @@ pub struct QueryBuilder<K> {
     offset: u64,
     include_empty: bool,
     sort_direction: SortDirection,
+    from: Option<Bytes>,
 }
 
 impl<K> QueryBuilder<K> {
@@ -187,6 +188,19 @@ impl<K> QueryBuilder<K> {
     /// Filter by key prefix.
     pub fn key_prefix(mut self, key: impl AsRef<[u8]>) -> Self {
         self.filter_key = KeyFilter::Prefix(key.as_ref().to_vec().into());
+        self
+    }
+    /// Filter by key prefix, starting from a cursor position.
+    ///
+    /// Only keys at or after `from` will be returned. The seek is performed
+    /// at the B-tree level (O(log n)).
+    pub fn key_prefix_from(
+        mut self,
+        prefix: impl AsRef<[u8]>,
+        from: impl AsRef<[u8]>,
+    ) -> Self {
+        self.filter_key = KeyFilter::Prefix(prefix.as_ref().to_vec().into());
+        self.from = Some(from.as_ref().to_vec().into());
         self
     }
     /// Filter by author.
@@ -258,6 +272,7 @@ impl From<QueryBuilder<SingleLatestPerKeyQuery>> for Query {
             offset: builder.offset,
             include_empty: builder.include_empty,
             sort_direction: builder.sort_direction,
+            from: builder.from,
         }
     }
 }
@@ -272,6 +287,7 @@ impl From<QueryBuilder<FlatQuery>> for Query {
             offset: builder.offset,
             include_empty: builder.include_empty,
             sort_direction: builder.sort_direction,
+            from: builder.from,
         }
     }
 }
@@ -287,6 +303,10 @@ pub struct Query {
     offset: u64,
     include_empty: bool,
     sort_direction: SortDirection,
+    /// When set together with a `KeyFilter::Prefix`, the cursor position
+    /// from which the prefix scan starts. Keys strictly before this
+    /// position are skipped at the B-tree level (O(log n) seek).
+    pub(crate) from: Option<Bytes>,
 }
 
 impl Query {

--- a/src/store/fs/bounds.rs
+++ b/src/store/fs/bounds.rs
@@ -103,7 +103,7 @@ impl From<(Bound<RecordsIdOwned>, Bound<RecordsIdOwned>)> for RecordsBounds {
 /// Supports bounds by key.
 pub struct ByKeyBounds(Bound<RecordsByKeyIdOwned>, Bound<RecordsByKeyIdOwned>);
 impl ByKeyBounds {
-    pub fn new(ns: NamespaceId, matcher: &KeyFilter) -> Self {
+    pub fn new(ns: NamespaceId, matcher: &KeyFilter, from: Option<&[u8]>) -> Self {
         match matcher {
             KeyFilter::Any => Self::namespace(ns),
             KeyFilter::Exact(key) => {
@@ -112,7 +112,8 @@ impl ByKeyBounds {
                 Self(Bound::Included(start), Bound::Included(end))
             }
             KeyFilter::Prefix(ref prefix) => {
-                let start = Bound::Included((ns.to_bytes(), prefix.clone(), [0u8; 32]));
+                let start_key = from.unwrap_or(prefix);
+                let start = Bound::Included((ns.to_bytes(), Bytes::copy_from_slice(start_key), [0u8; 32]));
 
                 let mut ns_end = ns.to_bytes();
                 let mut key_end = prefix.to_vec();
@@ -245,14 +246,14 @@ mod tests {
         );
         assert_eq!(bounds.end_bound(), Bound::Unbounded);
 
-        let bounds = ByKeyBounds::new(ns, &KeyFilter::Any);
+        let bounds = ByKeyBounds::new(ns, &KeyFilter::Any, None);
         assert_eq!(
             bounds.start_bound(),
             Bound::Included(&(ns.to_bytes(), Bytes::new(), [0u8; 32]))
         );
         assert_eq!(bounds.end_bound(), Bound::Unbounded);
 
-        let bounds = ByKeyBounds::new(ns, &KeyFilter::Prefix(vec![1u8].into()));
+        let bounds = ByKeyBounds::new(ns, &KeyFilter::Prefix(vec![1u8].into()), None);
         assert_eq!(
             bounds.start_bound(),
             Bound::Included(&(ns.to_bytes(), vec![1u8].into(), [0u8; 32]))
@@ -262,7 +263,7 @@ mod tests {
             Bound::Excluded(&(ns.to_bytes(), vec![2u8].into(), [0u8; 32]))
         );
 
-        let bounds = ByKeyBounds::new(ns, &KeyFilter::Prefix(vec![255u8].into()));
+        let bounds = ByKeyBounds::new(ns, &KeyFilter::Prefix(vec![255u8].into()), None);
         assert_eq!(
             bounds.start_bound(),
             Bound::Included(&(ns.to_bytes(), vec![255u8].into(), [0u8; 32]))
@@ -272,7 +273,7 @@ mod tests {
         let ns = NamespaceId::from(&[2u8; 32]);
         let mut ns_end = ns.to_bytes();
         ns_end[31] = 3u8;
-        let bounds = ByKeyBounds::new(ns, &KeyFilter::Prefix(vec![255u8].into()));
+        let bounds = ByKeyBounds::new(ns, &KeyFilter::Prefix(vec![255u8].into()), None);
         assert_eq!(
             bounds.start_bound(),
             Bound::Included(&(ns.to_bytes(), vec![255u8].into(), [0u8; 32]))
@@ -282,7 +283,7 @@ mod tests {
             Bound::Excluded(&(ns_end, Bytes::new(), [0u8; 32]))
         );
 
-        let bounds = ByKeyBounds::new(ns, &KeyFilter::Exact(vec![1u8].into()));
+        let bounds = ByKeyBounds::new(ns, &KeyFilter::Exact(vec![1u8].into()), None);
         assert_eq!(
             bounds.start_bound(),
             Bound::Included(&(ns.to_bytes(), vec![1u8].into(), [0u8; 32]))

--- a/src/store/fs/bounds.rs
+++ b/src/store/fs/bounds.rs
@@ -113,6 +113,10 @@ impl ByKeyBounds {
             }
             KeyFilter::Prefix(ref prefix) => {
                 let start_key = from.unwrap_or(prefix);
+                debug_assert!(
+                    start_key.starts_with(prefix.as_ref()),
+                    "cursor `from` must start with the given prefix"
+                );
                 let start = Bound::Included((ns.to_bytes(), Bytes::copy_from_slice(start_key), [0u8; 32]));
 
                 let mut ns_end = ns.to_bytes();
@@ -291,6 +295,26 @@ mod tests {
         assert_eq!(
             bounds.end_bound(),
             Bound::Included(&(ns.to_bytes(), vec![1u8].into(), [255u8; 32]))
+        );
+    }
+
+    #[test]
+    fn by_key_bounds_prefix_from_cursor() {
+        let ns = NamespaceId::from(&[1u8; 32]);
+
+        let bounds = ByKeyBounds::new(ns, &KeyFilter::Prefix(vec![b'e', b'v', b't', b':'].into()), Some(b"evt:01JABC..."));
+        assert_eq!(
+            bounds.start_bound(),
+            Bound::Included(&(ns.to_bytes(), Bytes::from_static(b"evt:01JABC..."), [0u8; 32])),
+            "lower bound should be the cursor, not the prefix"
+        );
+
+        let mut key_end = b"evt:".to_vec();
+        increment_by_one(&mut key_end);
+        assert_eq!(
+            bounds.end_bound(),
+            Bound::Excluded(&(ns.to_bytes(), Bytes::from(key_end), [0u8; 32])),
+            "upper bound should still be prefix+1"
         );
     }
 }

--- a/src/store/fs/query.rs
+++ b/src/store/fs/query.rs
@@ -63,8 +63,9 @@ impl QueryIterator {
                 range,
                 author_filter,
                 latest_per_key,
+                from,
             } => {
-                let bounds = ByKeyBounds::new(namespace, &range);
+                let bounds = ByKeyBounds::new(namespace, &range, from.as_deref());
                 let range =
                     RecordsByKeyRange::with_bounds(tables.records_by_key, tables.records, bounds)?;
                 let selector = latest_per_key.then(LatestPerKeySelector::default);

--- a/src/store/util.rs
+++ b/src/store/util.rs
@@ -14,6 +14,8 @@ pub enum IndexKind {
         range: KeyFilter,
         author_filter: AuthorFilter,
         latest_per_key: bool,
+        /// When set, the lower bound for the prefix scan.
+        from: Option<bytes::Bytes>,
     },
 }
 
@@ -25,6 +27,7 @@ impl From<&Query> for IndexKind {
                     range: query.filter_key.clone(),
                     author_filter: AuthorFilter::Any,
                     latest_per_key: false,
+                    from: query.from.clone(),
                 },
                 _ => IndexKind::AuthorKey {
                     range: query.filter_author.clone(),
@@ -35,6 +38,7 @@ impl From<&Query> for IndexKind {
                 range: query.filter_key.clone(),
                 author_filter: query.filter_author.clone(),
                 latest_per_key: true,
+                from: query.from.clone(),
             },
         }
     }


### PR DESCRIPTION
## Summary

Adds an optional `from` cursor field to the `Query` struct that enables B-tree-level seeks during prefix scans.

## Motivation

The current `key_prefix` filter always starts iteration from the beginning of the prefix range. For applications maintaining a cursor position (e.g., syncing event logs), this forces O(n) client-side skipping via `offset`. With this change, the B-tree seeks directly to the cursor position in O(log n).

## Changes

- Add `from: Option<Bytes>` field to `Query` and `QueryBuilder` (`store.rs`)
- Add `key_prefix_from(prefix, from)` builder method (`store.rs`)
- Pass cursor through `IndexKind::KeyAuthor` to `ByKeyBounds::new` (`util.rs`, `bounds.rs`, `query.rs`)
- When `from` is set with a `Prefix` filter, the lower bound becomes the cursor position instead of the prefix start

## Backward Compatibility

Fully backward-compatible. When `from` is `None` (default), behavior is identical to current `key_prefix`. The wire format adds an optional field that defaults to `None`.

## Usage

```rust
// Iterate from a known cursor position
let stream = doc.get_many(
    Query::all()
        .sort_by(SortBy::KeyAuthor, SortDirection::Asc)
        .key_prefix_from("evt:", "evt:01JABC...")
        .limit(100)
).await?;
```