### PR TITLE
fix!: return the sync outcome from BobState::run

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -139,7 +139,6 @@ where
     }
 
     let namespace = state.namespace();
-    let outcome = state.into_outcome();
 
     send_stream
         .finish()
@@ -155,7 +154,7 @@ where
 
     let t_process = t_start.elapsed() - t_connect;
     span.in_scope(|| match &res {
-        Ok(_res) => {
+        Ok((_, outcome)) => {
             debug!(
                 ?t_connect,
                 ?t_process,
@@ -169,7 +168,7 @@ where
         }
     });
 
-    let namespace = res?;
+    let (namespace, outcome) = res?;
 
     let timings = Timings {
         connect: t_connect,

--- a/src/net/codec.rs
+++ b/src/net/codec.rs
@@ -100,7 +100,7 @@ pub(super) async fn run_alice<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
     let mut reader = FramedRead::new(reader, SyncCodec);
     let mut writer = FramedWrite::new(writer, SyncCodec);
 
-    let mut progress = Some(SyncOutcome::default());
+    let mut progress = SyncOutcome::default();
 
     // Init message
 
@@ -124,12 +124,11 @@ pub(super) async fn run_alice<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
             }
             Message::Sync(msg) => {
                 trace!("recv process message");
-                let current_progress = progress.take().unwrap();
                 let (reply, next_progress) = handle
-                    .sync_process_message(namespace, msg, peer_bytes, current_progress)
+                    .sync_process_message(namespace, msg, peer_bytes, progress)
                     .await
                     .map_err(ConnectError::sync)?;
-                progress = Some(next_progress);
+                progress = next_progress;
                 if let Some(msg) = reply {
                     trace!("send process message");
                     writer
@@ -147,7 +146,7 @@ pub(super) async fn run_alice<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
     }
 
     trace!("done");
-    Ok(progress.unwrap())
+    Ok(progress)
 }
 
 /// Runs the receiver side of the sync protocol.
@@ -166,15 +165,13 @@ where
     Fut: Future<Output = AcceptOutcome>,
 {
     let mut state = BobState::new(peer);
-    let namespace = state.run(writer, reader, handle, accept_cb).await?;
-    Ok((namespace, state.into_outcome()))
+    state.run(writer, reader, handle, accept_cb).await
 }
 
 /// State for the receiver side of the sync protocol.
 pub struct BobState {
     namespace: Option<NamespaceId>,
     peer: PublicKey,
-    progress: Option<SyncOutcome>,
 }
 
 impl BobState {
@@ -183,7 +180,6 @@ impl BobState {
         Self {
             peer,
             namespace: None,
-            progress: Some(Default::default()),
         }
     }
 
@@ -192,13 +188,16 @@ impl BobState {
     }
 
     /// Handle connection and run to end.
+    ///
+    /// On success, returns the synced namespace and the [`SyncOutcome`] for
+    /// the connection.
     pub async fn run<R, W, F, Fut>(
         &mut self,
         writer: W,
         reader: R,
         sync: SyncHandle,
         accept_cb: F,
-    ) -> Result<NamespaceId, AcceptError>
+    ) -> Result<(NamespaceId, SyncOutcome), AcceptError>
     where
         R: AsyncRead + Unpin,
         W: AsyncWrite + Unpin,
@@ -207,6 +206,7 @@ impl BobState {
     {
         let mut reader = FramedRead::new(reader, SyncCodec);
         let mut writer = FramedWrite::new(writer, SyncCodec);
+        let mut progress = SyncOutcome::default();
         while let Some(msg) = reader.next().await {
             let msg = msg.map_err(|e| self.fail(e))?;
             let next = match (msg, self.namespace.as_ref()) {
@@ -232,22 +232,15 @@ impl BobState {
                             });
                         }
                     }
-                    let last_progress = self.progress.take().unwrap();
                     let next = sync
-                        .sync_process_message(
-                            namespace,
-                            message,
-                            *self.peer.as_bytes(),
-                            last_progress,
-                        )
+                        .sync_process_message(namespace, message, *self.peer.as_bytes(), progress)
                         .await;
                     self.namespace = Some(namespace);
                     next
                 }
                 (Message::Sync(msg), Some(namespace)) => {
                     trace!("recv process message");
-                    let last_progress = self.progress.take().unwrap();
-                    sync.sync_process_message(*namespace, msg, *self.peer.as_bytes(), last_progress)
+                    sync.sync_process_message(*namespace, msg, *self.peer.as_bytes(), progress)
                         .await
                 }
                 (Message::Init { .. }, Some(_)) => {
@@ -260,8 +253,8 @@ impl BobState {
                     return Err(self.fail(anyhow!("unexpected sync abort message")));
                 }
             };
-            let (reply, progress) = next.map_err(|e| self.fail(e))?;
-            self.progress = Some(progress);
+            let (reply, next_progress) = next.map_err(|e| self.fail(e))?;
+            progress = next_progress;
             match reply {
                 Some(msg) => {
                     trace!("send process message");
@@ -276,18 +269,15 @@ impl BobState {
 
         trace!("done");
 
-        self.namespace()
-            .ok_or_else(|| self.fail(anyhow!("Stream closed before init message")))
+        let namespace = self
+            .namespace()
+            .ok_or_else(|| self.fail(anyhow!("Stream closed before init message")))?;
+        Ok((namespace, progress))
     }
 
     /// Get the namespace that is synced, if available.
     pub fn namespace(&self) -> Option<NamespaceId> {
         self.namespace
-    }
-
-    /// Consume self and get the [`SyncOutcome`] for this connection.
-    pub fn into_outcome(self) -> SyncOutcome {
-        self.progress.unwrap()
     }
 }
 


### PR DESCRIPTION
## Problem

BobState is defined the following way:

```rust
pub struct BobState {
    namespace: Option<NamespaceId>,
    peer: PublicKey,
    progress: Option<SyncOutcome>,
}
```

With `progress` being `Option<SyncOutcome>`.

The `BobState::into_outcome` function assumed that `progress` would never be `None` when it was called:

```rust
/// Consume self and get the [`SyncOutcome`] for this connection.
pub fn into_outcome(self) -> SyncOutcome {
    self.progress.unwrap()
}
```

But this was not always true. If you look at `handle_connection`, it does this:

```rust
let mut state = BobState::new(peer);
let res = state
    .run(/* ... */)
// ...
let outcome = state.into_outcome();
```

In other words, `handle_connection` assumes that after `run()` returns, even when it returns an error, progress is `Some(...)`.

But there is a code path where this is not true. If you look at the implementation of `BobState::run`, it sets progress to `None`, then sets it back to Some(...) only in some cases:

```rust
// In BobState::run

// self.progress is set to None
let last_progress = self.progress.take().unwrap();

// ...
// Then, self.progress is supposed to be set back to Some(...) a little later in the function: 
// ...

let (reply, progress) = next.map_err(|e| self.fail(e))?;
self.progress = Some(progress); 
```

But maybe you can see the issue. if `next` is `Err(...)`, we will hit the `?` and `self.progress` will stay `None`. And it is possible for `next` to be `Err(...)`. When this happened to me, the trigger was some failure in the docs engine that I haven't fully diagnosed, but any error from `sync_process_message` produces it. But the point is, if `next` is Err, then `self.progress` is `None`, which means `BobState::into_outcome` will panic!

(I hit this in production)

## Solution

IMO, there is a mismatch in the code, where `BobState::progress` should 
1. only be accessed on a successful sync 
2. always be available on a successful sync

But currently, it is just an `Option<...>` on BobState, which means it can be accessed on an unsuccessful sync, and the type system doesn't even guarantee that it's always available on a successful sync.

Both can be fixed if we take it out of BobState entirely, and move it to the value `BobState::run` returns in the success case:

```rust
pub async fn run(...) -> Result<(NamespaceId, SyncOutcome), AcceptError>
```

By doing this, we make it impossible to even think of accessing the `SyncOutcome` in run's error case, and removes the need for a `.unwrap`.

I also took the opportunity to clean up `run_alice` slightly, as it also had an unnecessary `.unwrap`. (That one is safe, but a simple change to the code removes it entirely.)

## Breaking Changes

Type signature of `BobState::run` changes:

```rust
pub async fn run(...) -> Result<NamespaceId, AcceptError> // before
pub async fn run(...) -> Result<(NamespaceId, SyncOutcome), AcceptError> // after
```

`BobState::into_outcome` is removed.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
