### PR TITLE
chore: run scheduled CI jobs earlier

### DIFF
--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -4,8 +4,8 @@ name: Beta Rust
 
 on:
   schedule:
-    # 06:50 UTC every Monday
-    - cron: '50 6 * * 1'
+    # 02:50 UTC every Monday
+    - cron: '50 2 * * 1'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -4,8 +4,8 @@ name: Cleanup
 
 on:
   schedule:
-    # 06:50 UTC every Monday
-    - cron: '50 6 * * 1'
+    # 02:50 UTC every Monday
+    - cron: '50 2 * * 1'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -23,8 +23,8 @@ on:
   pull_request:
     types: [ 'labeled', 'unlabeled', 'opened', 'synchronize', 'reopened' ]
   schedule:
-    # 06:30 UTC every day
-    - cron: '30 6 * * *'
+    # 02:30 UTC every day
+    - cron: '30 2 * * *'
   workflow_dispatch:
     inputs:
       branch:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,9 +520,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,7 +1224,7 @@ dependencies = [
  "diatomic-waker",
  "futures-core",
  "pin-project-lite",
- "spin 0.10.0",
+ "spin 0.10.1",
 ]
 
 [[package]]
@@ -1515,7 +1515,7 @@ dependencies = [
  "hash32",
  "rustc_version",
  "serde",
- "spin 0.9.8",
+ "spin 0.9.9",
  "stable_deref_trait",
 ]
 
@@ -4183,18 +4183,18 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spki"


### PR DESCRIPTION
## Description

This moves scheduled CI jobs outside of engineering daytime.

## Breaking Changes

n/a

## Notes & open questions

Also makes cargo deny and docs happy.

## Change checklist

- [x] Self-review.