### PR TITLE
docs: fix `SyncEvent` property comments

### DIFF
--- a/src/engine/live.rs
+++ b/src/engine/live.rs
@@ -835,9 +835,9 @@ pub struct SyncEvent {
     pub peer: PublicKey,
     /// Origin of the sync exchange
     pub origin: Origin,
-    /// Timestamp when the sync started
-    pub finished: SystemTime,
     /// Timestamp when the sync finished
+    pub finished: SystemTime,
+    /// Timestamp when the sync started
     pub started: SystemTime,
     /// Result of the sync operation
     pub result: std::result::Result<SyncDetails, String>,


### PR DESCRIPTION
Quite minor, but this really bothered me.

## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->

- The comments for `SyncEvent.finished` and `SyncEvent.started` were flipped

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
