### PR TITLE
fix: clamp remote sync ranges to the session namespace

### DIFF
--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -805,22 +805,31 @@ impl<'a> crate::ranger::Store<SignedEntry> for StoreInstance<'a> {
             // regular range: iter1 = x <= t < y, iter2 = none
             Ordering::Less => {
                 // iterator for entries from range.x to range.y
+                //
+                // Both endpoints come from the remote peer, so the bounds have to be
+                // clamped to our namespace; otherwise a range naming another namespace
+                // would read that document's entries out of the shared records table.
                 let start = Bound::Included(range.x().to_byte_tuple());
                 let end = Bound::Excluded(range.y().to_byte_tuple());
-                let bounds = RecordsBounds::new(start, end);
+                let bounds = RecordsBounds::new(start, end).clamp_to_namespace(&self.namespace);
                 let iter = RecordsRange::with_bounds(&tables.records, bounds)?;
                 chain_none(iter)
             }
             // split range: iter1 = start <= t < y, iter2 = x <= t <= end
             Ordering::Greater => {
                 // iterator for entries from start to range.y
+                //
+                // `from_start`/`to_end` pin only one side to our namespace, so the
+                // remote-supplied side still needs clamping.
                 let end = Bound::Excluded(range.y().to_byte_tuple());
-                let bounds = RecordsBounds::from_start(&self.namespace, end);
+                let bounds = RecordsBounds::from_start(&self.namespace, end)
+                    .clamp_to_namespace(&self.namespace);
                 let iter = RecordsRange::with_bounds(&tables.records, bounds)?;
 
                 // iterator for entries from range.x to end
                 let start = Bound::Included(range.x().to_byte_tuple());
-                let bounds = RecordsBounds::to_end(&self.namespace, start);
+                let bounds = RecordsBounds::to_end(&self.namespace, start)
+                    .clamp_to_namespace(&self.namespace);
                 let iter2 = RecordsRange::with_bounds(&tables.records, bounds)?;
 
                 iter.chain(Some(iter2).into_iter().flatten())
@@ -1047,6 +1056,57 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![key1, key2]
         );
+        Ok(())
+    }
+
+    /// `get_range` must never return entries outside the namespace it is pinned to.
+    ///
+    /// All namespaces share one records table, keyed `(namespace, author, key)`, so the
+    /// query bounds are the only thing keeping documents apart. The range in a
+    /// `RangeItem` is remote-supplied and unvalidated, and the resulting diff is echoed
+    /// straight back to the peer — so a range naming a foreign namespace must not widen
+    /// what the session can see, in any of the three orderings.
+    #[test]
+    fn get_range_stays_within_its_namespace() -> Result<()> {
+        let dbfile = tempfile::NamedTempFile::new()?;
+        let mut store = Store::persistent(dbfile.path())?;
+        let author = store.new_author(&mut rand::rng())?;
+
+        let ours = NamespaceSecret::new(&mut rand::rng());
+        let theirs = NamespaceSecret::new(&mut rand::rng());
+        store.new_replica(ours.clone())?;
+        store.new_replica(theirs.clone())?;
+        for ns in [&ours, &theirs] {
+            let mut wrapper = StoreInstance::new(ns.id(), &mut store);
+            let id = RecordIdentifier::new(ns.id(), author.id(), b"key");
+            let entry = Entry::new(id, Record::current_from_data(b"value"));
+            wrapper.entry_put(SignedEntry::from_entry(entry, ns, &author))?;
+        }
+
+        // Endpoints spanning the whole table, i.e. naming neither namespace in
+        // particular. `min < max`, so swapping them walks each of the two branches that
+        // build bounds out of remote input.
+        let min = RecordIdentifier::new(NamespaceId::from(&[0u8; 32]), author.id(), b"");
+        let max = RecordIdentifier::new(NamespaceId::from(&[255u8; 32]), author.id(), b"");
+
+        let mut wrapper = StoreInstance::new(ours.id(), &mut store);
+        for (label, range) in [
+            ("less", Range::new(min.clone(), max.clone())),
+            ("greater", Range::new(max.clone(), min.clone())),
+            ("equal", Range::new(min.clone(), min.clone())),
+        ] {
+            let leaked = wrapper
+                .get_range(range)?
+                .map(|entry| entry.map(|e| e.namespace()))
+                .collect::<Result<Vec<_>>>()?
+                .into_iter()
+                .filter(|ns| *ns != ours.id())
+                .collect::<Vec<_>>();
+            assert!(
+                leaked.is_empty(),
+                "{label} range leaked entries from another namespace: {leaked:?}"
+            );
+        }
         Ok(())
     }
 

--- a/src/store/fs/bounds.rs
+++ b/src/store/fs/bounds.rs
@@ -61,6 +61,45 @@ impl RecordsBounds {
         Self::new(start, Self::namespace_end(ns))
     }
 
+    /// Intersect these bounds with `ns`.
+    ///
+    /// Every namespace shares the same records table, so the bounds are the only thing
+    /// keeping documents apart. Sync range endpoints arrive from the remote peer
+    /// unvalidated and may name any namespace, so they have to be intersected with the
+    /// namespace the session is pinned to: a range reaching into another document then
+    /// selects nothing instead of reading it.
+    pub fn clamp_to_namespace(self, ns: &NamespaceId) -> Self {
+        let Self(start, end) = self;
+        // Both `namespace_start` and every caller's start are `Included`; the tighter of
+        // two lower bounds is the greater one. Unexpected shapes fall back to the
+        // namespace bound, which is never wider than what was asked for.
+        let start = match (start, Self::namespace_start(ns)) {
+            (Bound::Included(remote), Bound::Included(ns_start)) => {
+                Bound::Included(remote.max(ns_start))
+            }
+            (_, ns_start) => ns_start,
+        };
+        // `namespace_end` is `Excluded`, or `Unbounded` for the last namespace, in which
+        // case the remote's own end is already within it.
+        let end = match (end, Self::namespace_end(ns)) {
+            (Bound::Excluded(remote), Bound::Excluded(ns_end)) => {
+                Bound::Excluded(remote.min(ns_end))
+            }
+            (Bound::Excluded(remote), Bound::Unbounded) => Bound::Excluded(remote),
+            (_, ns_end) => ns_end,
+        };
+        // The intersection is empty whenever the range covers only foreign namespaces.
+        // Normalize that to a range selecting nothing, as inverted bounds are not a
+        // valid query.
+        if let (Bound::Included(s), Bound::Excluded(e)) = (&start, &end) {
+            if s >= e {
+                let empty = (ns.to_bytes(), [0u8; 32], Bytes::new());
+                return Self(Bound::Included(empty.clone()), Bound::Excluded(empty));
+            }
+        }
+        Self(start, end)
+    }
+
     pub fn as_ref(&self) -> (Bound<RecordsId<'_>>, Bound<RecordsId<'_>>) {
         fn map(id: &RecordsIdOwned) -> RecordsId<'_> {
             (&id.0, &id.1, &id.2[..])


### PR DESCRIPTION
## Description

All namespaces share one records table keyed `(namespace[32], author[32], key[])`,
so the query bounds are the only thing keeping documents apart. But `get_range`
(`src/store/fs.rs`) builds those bounds from the range endpoints in an incoming
`RangeItem`:

```rust
Ordering::Equal   => RecordsBounds::namespace(self.namespace)   // correct
Ordering::Less    => RecordsBounds::new(start, end)             // both remote
Ordering::Greater => from_start(&self.namespace, end)           // end remote
                     to_end(&self.namespace, start)             // start remote
```

Those endpoints are remote-controlled: `RecordIdentifier` is a raw `Bytes` with a
derived `Deserialize`, and `Message::validate_limits` counts parts and entries
without ever inspecting `range`. `RecordsBounds::new` is a passthrough and
`RecordsRange::with_bounds` applies no post-filter, so nothing downstream catches
it. `get_fingerprint` delegates to `get_range` and inherits the same flaw.

**Impact.** The computed diff is echoed straight back to the peer, and the
namespace pin and signature verification in `validate_entry` apply only to
*incoming* entries, never to the outgoing diff. Combined with `accept_request`,
which admits any authenticated peer for any namespace in the local sync set with
no per-namespace peer allowlist, a peer holding a legitimate ticket for **one**
document can read **every** document on the node — namespace ids, author keys,
full record keys, timestamps, content lengths, content hashes and both
signatures.

One frame is enough:

```
RangeItem {
    range:  Range { x: (0x00 * 64), y: (0xFF * 64) },   // spans the whole table
    values: vec![],
    have_local: false,
}
```

`have_local: false` makes the node compute `diff = get_range(range)`, the empty
`values` filters nothing, and the diff is returned in the reply.
`MAX_ENTRIES_PER_SYNC_MESSAGE` caps a reply at 2048 entries, so a larger store is
paged by splitting — an inconvenience, not a mitigation.

That is worse than a pure metadata leak in two ways: `Capability::Read` **is** the
namespace id, so leaked ids can be redeemed for full sync sessions through the
front door; and leaked content hashes are directly fetchable from the blobs
store. Writes are unaffected — entry signatures bind both namespace and author,
and all three ingress paths verify before `put`.

**Fix.** Add `RecordsBounds::clamp_to_namespace` and apply it to every branch
that consumes remote input, including *both* sub-ranges of `Greater`, where
`from_start`/`to_end` pin only one side each. An empty intersection — what a
range naming only foreign namespaces clamps to — normalizes to a range selecting
nothing, since inverted bounds are not a valid redb query.

## Breaking Changes

None. Normal traffic never exercised the gap: sessions start at
`Range::new(x, x)` (the `Equal` branch) and recursion only produces in-namespace
split points, which is presumably why this went unnoticed. Reconciliation is
unaffected — `sync_big`, `sync_full_basic`, `sync_gossip_bulk` and
`sync_restart_node` all pass.

## Notes & open questions

- Found during a security review of [our fork](https://github.com/holon-technologies/iroh),
  which imported iroh-docs v0.101.0. Present since at least
  `refactor: renames iroh-sync & iroh-bytes (#2271)` (2024-05-06) and possibly
  earlier under the `iroh-sync` name.
- **This is already public**, which I regret: we fixed it in our fork and pushed
  before recognising it was inherited from upstream rather than introduced by us.
  Details are in holon-technologies/iroh#24. Happy to help with coordination.
- Written for edition 2021, so the emptiness check uses a nested `if let` rather
  than a let-chain.
- Adjacent, deliberately **not** fixed here: `RecordIdentifier(Bytes)`
  deserializes with no length invariant, while `to_byte_tuple`/`namespace()`/
  `author()` slice `0..32` and `32..64`. A remote-supplied identifier shorter
  than 64 bytes panics the docs actor thread, which runs with no `catch_unwind`.
  That is availability-only so I left it out of a security fix, but it shares the
  root cause and the same validation would close it. Say the word and I will add
  it here or in a separate PR.
- The new test drives all three orderings with endpoints spanning the whole table
  and asserts nothing outside the session namespace comes back. It was confirmed
  to fail on unpatched `main` (leaking the other namespace via the `Less` branch).
- 77 lib + 11 integration tests + doctests pass; `cargo clippy --all-targets` and
  `cargo fmt` clean.

## Change checklist

- [x] Tests if relevant.
- [x] All breaking changes documented.
- [ ] Self-review. <!-- reviewer: this branch was prepared with Claude Code and
      needs a human read before merge; I have not ticked the template's
      human-authored items on my own behalf. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
