### PR TITLE
fix(sync): reject record identifiers shorter than 64 bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,7 +1102,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1453,9 +1453,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3724,7 +3724,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3816,7 +3816,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3920,7 +3920,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4372,7 +4372,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5199,7 +5199,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -25,7 +25,7 @@ use n0_future::{
     time::{Duration, SystemTime},
     IterExt,
 };
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 pub use crate::heads::AuthorHeads;
 use crate::{
@@ -1004,8 +1004,25 @@ const AUTHOR_BYTES: std::ops::Range<usize> = 32..64;
 const KEY_BYTES: std::ops::RangeFrom<usize> = 64..;
 
 /// The identifier of a record.
-#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+///
+/// Wraps `namespace || author || key`, so the buffer is always at least 64 bytes long. The
+/// accessors slice those ranges without a bounds check and rely on that, which is why
+/// [`Deserialize`] rejects anything shorter.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 pub struct RecordIdentifier(Bytes);
+
+impl<'de> Deserialize<'de> for RecordIdentifier {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let bytes = Bytes::deserialize(deserializer)?;
+        if bytes.len() < KEY_BYTES.start {
+            return Err(serde::de::Error::invalid_length(
+                bytes.len(),
+                &"a record identifier of at least 64 bytes",
+            ));
+        }
+        Ok(Self(bytes))
+    }
+}
 
 impl Default for RecordIdentifier {
     fn default() -> Self {
@@ -1464,6 +1481,21 @@ mod tests {
         let actual = store.content_hashes()?.collect::<Result<HashSet<Hash>>>()?;
         assert_eq!(actual, expected);
         Ok(())
+    }
+
+    /// A remote-supplied identifier shorter than 64 bytes must be rejected at decode time,
+    /// before the accessors slice `0..32` and `32..64` and panic the sync actor thread.
+    #[test]
+    fn test_record_identifier_rejects_short_input() {
+        let short = postcard::to_allocvec(&Bytes::from_static(b"\x01\x02")).unwrap();
+        assert!(postcard::from_bytes::<RecordIdentifier>(&short).is_err());
+
+        let id = RecordIdentifier::default();
+        let encoded = postcard::to_allocvec(&id).unwrap();
+        assert_eq!(
+            postcard::from_bytes::<RecordIdentifier>(&encoded).unwrap(),
+            id
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

`RecordIdentifier` wraps `Bytes` and derives `Deserialize`, so it accepts any length. But: `to_byte_tuple`, `namespace` and `author` slice `0..32` and `32..64` without a bounds check. A remote identifier shorter than 64 bytes makes us panic. Bad.

This fixes it with a custom `Deserialize` impl that enforces the length.

## Breaking Changes

None.


## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
