### PR TITLE
fix: Improve API around untrusted range bounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,7 +1102,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1453,9 +1453,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3724,7 +3724,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3816,7 +3816,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3920,7 +3920,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4372,7 +4372,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5199,7 +5199,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -805,31 +805,22 @@ impl<'a> crate::ranger::Store<SignedEntry> for StoreInstance<'a> {
             // regular range: iter1 = x <= t < y, iter2 = none
             Ordering::Less => {
                 // iterator for entries from range.x to range.y
-                //
-                // Both endpoints come from the remote peer, so the bounds have to be
-                // clamped to our namespace; otherwise a range naming another namespace
-                // would read that document's entries out of the shared records table.
                 let start = Bound::Included(range.x().to_byte_tuple());
                 let end = Bound::Excluded(range.y().to_byte_tuple());
-                let bounds = RecordsBounds::new(start, end).clamp_to_namespace(&self.namespace);
+                let bounds = RecordsBounds::untrusted(&self.namespace, start, end);
                 let iter = RecordsRange::with_bounds(&tables.records, bounds)?;
                 chain_none(iter)
             }
             // split range: iter1 = start <= t < y, iter2 = x <= t <= end
             Ordering::Greater => {
                 // iterator for entries from start to range.y
-                //
-                // `from_start`/`to_end` pin only one side to our namespace, so the
-                // remote-supplied side still needs clamping.
                 let end = Bound::Excluded(range.y().to_byte_tuple());
-                let bounds = RecordsBounds::from_start(&self.namespace, end)
-                    .clamp_to_namespace(&self.namespace);
+                let bounds = RecordsBounds::untrusted(&self.namespace, Bound::Unbounded, end);
                 let iter = RecordsRange::with_bounds(&tables.records, bounds)?;
 
                 // iterator for entries from range.x to end
                 let start = Bound::Included(range.x().to_byte_tuple());
-                let bounds = RecordsBounds::to_end(&self.namespace, start)
-                    .clamp_to_namespace(&self.namespace);
+                let bounds = RecordsBounds::untrusted(&self.namespace, start, Bound::Unbounded);
                 let iter2 = RecordsRange::with_bounds(&tables.records, bounds)?;
 
                 iter.chain(Some(iter2).into_iter().flatten())
@@ -866,13 +857,15 @@ impl<'a> crate::ranger::Store<SignedEntry> for StoreInstance<'a> {
         id: &RecordIdentifier,
     ) -> Result<Self::ParentIterator<'_>, Self::Error> {
         let tables = self.store.as_mut().tables()?;
-        ParentIterator::new(tables, id.namespace(), id.author(), id.key().to_vec())
+        // Pinned to the session namespace, not `id.namespace()`, so that a caller-supplied
+        // id cannot read another document even if entry validation is ever reordered.
+        ParentIterator::new(tables, self.namespace, id.author(), id.key().to_vec())
     }
 
     #[cfg(test)]
     fn prefixed_by(&mut self, id: &RecordIdentifier) -> Result<Self::RangeIterator<'_>> {
         let tables = self.store.as_mut().tables()?;
-        let bounds = RecordsBounds::author_prefix(id.namespace(), id.author(), id.key_bytes());
+        let bounds = RecordsBounds::author_prefix(self.namespace, id.author(), id.key_bytes());
         let iter = RecordsRange::with_bounds(&tables.records, bounds)?;
         Ok(chain_none(iter))
     }
@@ -882,7 +875,9 @@ impl<'a> crate::ranger::Store<SignedEntry> for StoreInstance<'a> {
         id: &RecordIdentifier,
         predicate: impl Fn(&Record) -> bool,
     ) -> Result<usize> {
-        let bounds = RecordsBounds::author_prefix(id.namespace(), id.author(), id.key_bytes());
+        // Pinned to the session namespace, not `id.namespace()`: this deletes records, so a
+        // caller-supplied id reaching another document would be worse than a read.
+        let bounds = RecordsBounds::author_prefix(self.namespace, id.author(), id.key_bytes());
         self.store.as_mut().modify(|tables| {
             let cb = |_k: RecordsId, v: RecordsValue| {
                 let (timestamp, _namespace_sig, _author_sig, len, hash) = v;
@@ -1059,53 +1054,73 @@ mod tests {
         Ok(())
     }
 
-    /// `get_range` must never return entries outside the namespace it is pinned to.
+    /// `get_range` must return exactly the entries of the namespace it is pinned to.
     ///
     /// All namespaces share one records table, keyed `(namespace, author, key)`, so the
-    /// query bounds are the only thing keeping documents apart. The range in a
-    /// `RangeItem` is remote-supplied and unvalidated, and the resulting diff is echoed
-    /// straight back to the peer — so a range naming a foreign namespace must not widen
-    /// what the session can see, in any of the three orderings.
+    /// query bounds are the only thing keeping documents apart. The range in a `RangeItem`
+    /// is remote-supplied and unvalidated, and the resulting diff is echoed straight back
+    /// to the peer.
     #[test]
-    fn get_range_stays_within_its_namespace() -> Result<()> {
+    fn test_get_range_stays_within_its_namespace() -> Result<()> {
         let dbfile = tempfile::NamedTempFile::new()?;
         let mut store = Store::persistent(dbfile.path())?;
         let author = store.new_author(&mut rand::rng())?;
 
+        // A foreign namespace on either side of ours, so that both halves of a wrapping
+        // range have something to leak.
         let ours = NamespaceSecret::new(&mut rand::rng());
-        let theirs = NamespaceSecret::new(&mut rand::rng());
-        store.new_replica(ours.clone())?;
-        store.new_replica(theirs.clone())?;
-        for ns in [&ours, &theirs] {
+        let (mut below, mut above) = (None, None);
+        while below.is_none() || above.is_none() {
+            let ns = NamespaceSecret::new(&mut rand::rng());
+            if ns.id() < ours.id() {
+                below = Some(ns);
+            } else {
+                above = Some(ns);
+            }
+        }
+        for ns in [&ours, &below.unwrap(), &above.unwrap()] {
+            store.new_replica(ns.clone())?;
             let mut wrapper = StoreInstance::new(ns.id(), &mut store);
             let id = RecordIdentifier::new(ns.id(), author.id(), b"key");
             let entry = Entry::new(id, Record::current_from_data(b"value"));
             wrapper.entry_put(SignedEntry::from_entry(entry, ns, &author))?;
         }
 
-        // Endpoints spanning the whole table, i.e. naming neither namespace in
-        // particular. `min < max`, so swapping them walks each of the two branches that
-        // build bounds out of remote input.
-        let min = RecordIdentifier::new(NamespaceId::from(&[0u8; 32]), author.id(), b"");
-        let max = RecordIdentifier::new(NamespaceId::from(&[255u8; 32]), author.id(), b"");
+        let record_id = |namespace: [u8; 32], author: [u8; 32], key: &[u8]| {
+            RecordIdentifier::new(NamespaceId::from(&namespace), AuthorId::from(&author), key)
+        };
+        let min = record_id([0; 32], [0; 32], b"");
 
         let mut wrapper = StoreInstance::new(ours.id(), &mut store);
         for (label, range) in [
-            ("less", Range::new(min.clone(), max.clone())),
-            ("greater", Range::new(max.clone(), min.clone())),
+            // identity range: the whole replica
             ("equal", Range::new(min.clone(), min.clone())),
+            // regular range spanning the whole table
+            (
+                "less",
+                Range::new(min.clone(), record_id([255; 32], [255; 32], b"")),
+            ),
+            // wrapping range whose `start .. y` half spans everything below `y`
+            (
+                "greater/high",
+                Range::new(
+                    record_id([255; 32], [255; 32], b"\xff"),
+                    record_id([255; 32], [0; 32], b""),
+                ),
+            ),
+            // wrapping range whose `x .. end` half spans everything above `x`
+            (
+                "greater/low",
+                Range::new(record_id([0; 32], [0; 32], b"\x00"), min.clone()),
+            ),
         ] {
-            let leaked = wrapper
+            let returned = wrapper
                 .get_range(range)?
-                .map(|entry| entry.map(|e| e.namespace()))
-                .collect::<Result<Vec<_>>>()?
-                .into_iter()
-                .filter(|ns| *ns != ours.id())
-                .collect::<Vec<_>>();
-            assert!(
-                leaked.is_empty(),
-                "{label} range leaked entries from another namespace: {leaked:?}"
-            );
+                .map(|entry| entry.map(|entry| entry.namespace()))
+                .collect::<Result<Vec<_>>>()?;
+            // Exactly our own entry: nothing foreign leaked, and nothing legitimate was
+            // clamped away either.
+            assert_eq!(returned, vec![ours.id()], "{label} range");
         }
         Ok(())
     }

--- a/src/store/fs/bounds.rs
+++ b/src/store/fs/bounds.rs
@@ -53,49 +53,51 @@ impl RecordsBounds {
         Self::new(Self::namespace_start(&ns), Self::namespace_end(&ns))
     }
 
-    pub fn from_start(ns: &NamespaceId, end: Bound<RecordsIdOwned>) -> Self {
-        Self::new(Self::namespace_start(ns), end)
-    }
-
-    pub fn to_end(ns: &NamespaceId, start: Bound<RecordsIdOwned>) -> Self {
-        Self::new(start, Self::namespace_end(ns))
-    }
-
-    /// Intersect these bounds with `ns`.
+    /// Returns bounds for an untrusted `start`..`end`, intersected with the keys of `ns`.
     ///
-    /// Every namespace shares the same records table, so the bounds are the only thing
-    /// keeping documents apart. Sync range endpoints arrive from the remote peer
-    /// unvalidated and may name any namespace, so they have to be intersected with the
-    /// namespace the session is pinned to: a range reaching into another document then
-    /// selects nothing instead of reading it.
-    pub fn clamp_to_namespace(self, ns: &NamespaceId) -> Self {
-        let Self(start, end) = self;
-        // Both `namespace_start` and every caller's start are `Included`; the tighter of
-        // two lower bounds is the greater one. Unexpected shapes fall back to the
-        // namespace bound, which is never wider than what was asked for.
-        let start = match (start, Self::namespace_start(ns)) {
-            (Bound::Included(remote), Bound::Included(ns_start)) => {
-                Bound::Included(remote.max(ns_start))
-            }
-            (_, ns_start) => ns_start,
+    /// Every namespace shares one records table, so the bounds are the only thing keeping
+    /// documents apart. Sync range endpoints arrive from the remote peer unvalidated and
+    /// may name any namespace, so they have to be intersected with the namespace the
+    /// session is pinned to. A range reaching into another document then selects nothing
+    /// instead of reading it.
+    ///
+    /// This is the only constructor that accepts remote input.
+    pub fn untrusted(
+        ns: &NamespaceId,
+        start: Bound<RecordsIdOwned>,
+        end: Bound<RecordsIdOwned>,
+    ) -> Self {
+        // The tighter of two lower bounds is the greater one, and vice versa for upper bounds.
+        let ns_start = (ns.to_bytes(), [0u8; 32], Bytes::new());
+        let start = match start {
+            Bound::Included(start) if start > ns_start => Bound::Included(start),
+            Bound::Excluded(start) if start >= ns_start => Bound::Excluded(start),
+            _ => Bound::Included(ns_start),
         };
-        // `namespace_end` is `Excluded`, or `Unbounded` for the last namespace, in which
-        // case the remote's own end is already within it.
+        // `namespace_end` is `Unbounded` for the last namespace, which no end can exceed.
         let end = match (end, Self::namespace_end(ns)) {
-            (Bound::Excluded(remote), Bound::Excluded(ns_end)) => {
-                Bound::Excluded(remote.min(ns_end))
+            (Bound::Unbounded, ns_end) => ns_end,
+            (end, Bound::Unbounded) => end,
+            (Bound::Included(end), Bound::Excluded(ns_end)) if end < ns_end => Bound::Included(end),
+            (Bound::Excluded(end), Bound::Excluded(ns_end)) if end <= ns_end => {
+                Bound::Excluded(end)
             }
-            (Bound::Excluded(remote), Bound::Unbounded) => Bound::Excluded(remote),
             (_, ns_end) => ns_end,
         };
-        // The intersection is empty whenever the range covers only foreign namespaces.
-        // Normalize that to a range selecting nothing, as inverted bounds are not a
-        // valid query.
-        if let (Bound::Included(s), Bound::Excluded(e)) = (&start, &end) {
-            if s >= e {
-                let empty = (ns.to_bytes(), [0u8; 32], Bytes::new());
-                return Self(Bound::Included(empty.clone()), Bound::Excluded(empty));
-            }
+        // A range naming only foreign namespaces intersects to nothing. Normalize that to an
+        // explicitly empty range: redb tolerates inverted bounds, but `RecordsBounds` is a
+        // `RangeBounds`, and `BTreeMap::range` panics on them.
+        let inverted = match (&start, &end) {
+            (Bound::Included(start), Bound::Included(end)) => start > end,
+            (
+                Bound::Included(start) | Bound::Excluded(start),
+                Bound::Included(end) | Bound::Excluded(end),
+            ) => start >= end,
+            _ => false,
+        };
+        if inverted {
+            let empty = (ns.to_bytes(), [0u8; 32], Bytes::new());
+            return Self(Bound::Included(empty.clone()), Bound::Excluded(empty));
         }
         Self(start, end)
     }


### PR DESCRIPTION
## Description

Followup to #117: This improves the API around untrusted (remote-defined) range bounds to prevent future misuse. Also expands the test coverage to be more comprehensive.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
